### PR TITLE
makes it so .get doesn't create properties, only sets up an observable

### DIFF
--- a/list/list-test.js
+++ b/list/list-test.js
@@ -244,7 +244,7 @@ test("slice and join are observable by a compute (#1884)", function(){
 			deepEqual(newVal.get(), [2], "got a new DefineList");
 		}
 	});
-	sliced.getValueAndBind();
+	sliced.start();
 
 	var joined = new Observation(function(){
 		return list.join(",");
@@ -253,7 +253,7 @@ test("slice and join are observable by a compute (#1884)", function(){
 			equal(newVal, "2,3", "joined is observable");
 		}
 	});
-	joined.getValueAndBind();
+	joined.start();
 
 
 	list.shift();

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -81,7 +81,7 @@ QUnit.test("get and set can setup expandos", function(){
             QUnit.equal(newVal, "bar", "updated to bar");
         }
     });
-    oi.getValueAndBind();
+    oi.start();
 
     map.set("foo","bar");
 
@@ -144,7 +144,7 @@ QUnit.test("serialize responds to added props", function(){
             QUnit.deepEqual(newVal, {a: 1, b: 2}, "updated right");
         }
     });
-    oi.getValueAndBind();
+    oi.start();
 
     map.set({a: 1, b: 2});
 });
@@ -165,7 +165,7 @@ QUnit.test("creating a new key doesn't cause two changes", 1, function(){
             QUnit.deepEqual(newVal, {a: 1}, "updated right");
         }
     });
-    oi.getValueAndBind();
+    oi.start();
 
     map.set("a", 1);
 });
@@ -231,4 +231,15 @@ QUnit.test("serialize: function works (#38)", function(){
 QUnit.test("isMapLike", function(){
     var map = new DefineMap({});
     ok(canTypes.isMapLike(map), "is map like");
+});
+
+QUnit.test("get will not create properties", function(){
+    var method = function(){};
+    var MyMap = DefineMap.extend({
+        method: method
+    });
+    var m = new MyMap();
+    m.get("foo");
+
+    QUnit.equal(m.get("method"), method);
 });

--- a/map/map.js
+++ b/map/map.js
@@ -151,7 +151,7 @@ var DefineMap = Construct.extend("DefineMap",{
      */
     get: function(prop){
         if(arguments.length) {
-            if(prop in this) {
+            if(prop in this || Object.isSealed(this)) {
                 return this[prop];
             } else {
                 Observation.add(this, prop);

--- a/map/map.js
+++ b/map/map.js
@@ -136,8 +136,7 @@ var DefineMap = Construct.extend("DefineMap",{
      *
      * @signature `map.get(propName)`
      *
-     * Get a single property on a DefineMap instance.  If the property is not previously defined and
-     * the object is not [can-define/map/map.seal sealed], it will be dynamically added.
+     * Get a single property on a DefineMap instance.
      *
      * `.get(propName)` only should be used when reading properties that might not have been defined yet, but
      * will be later via [can-define/map/map.prototype.set].
@@ -152,8 +151,13 @@ var DefineMap = Construct.extend("DefineMap",{
      */
     get: function(prop){
         if(arguments.length) {
-            defineHelpers.defineExpando(this, prop);
-            return this[prop];
+            if(prop in this) {
+                return this[prop];
+            } else {
+                Observation.add(this, prop);
+                return this[prop];
+            }
+
         } else {
             return defineHelpers.serialize(this, 'get', {});
         }


### PR DESCRIPTION
Before this, if you called `.get("propName")`, all the getter / setters would be added to that project. 

This caused problems if stache tried to `.get("not")` or some other helper that shouldn't exist because it might add a property to a sealed object.  

This change makes it so 

 - if the property is `in` the map, its value is returned.
 - if the object is sealed, the undefined value is returned (because no future observable properties can be added, so there's no reason to call `Observation.add`)
- otherwise, setup `Observation.add` in case there is a future property.
