### PR TITLE
Implements iterators for maps.

### DIFF
--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1,8 +1,10 @@
 "use strict";
 var QUnit = require("steal-qunit");
+var define = require("can-define");
 var DefineMap = require("can-define/map/map");
 var Observation = require("can-observation");
 var canTypes = require("can-util/js/types/types");
+var each = require("can-util/js/each/each");
 
 QUnit.module("can-define/map/map");
 
@@ -249,4 +251,45 @@ QUnit.test("get will not create properties", function(){
     m.get("foo");
 
     QUnit.equal(m.get("method"), method);
+});
+
+QUnit.test("Properties are enumerable", function(){
+  QUnit.expect(4);
+
+  var VM = DefineMap.extend({
+    foo: "string"
+  });
+  var vm = new VM({ foo: "bar", baz: "qux" });
+
+  var i = 0;
+  each(vm, function(value, key){
+    if(i === 0) {
+      QUnit.equal(key, "foo");
+      QUnit.equal(value, "bar");
+    } else {
+      QUnit.equal(key, "baz");
+      QUnit.equal(value, "qux");
+    }
+    i++;
+  });
+});
+
+QUnit.test("Getters are not enumerable", function(){
+  QUnit.expect(2);
+
+  var MyMap = DefineMap.extend({
+    foo: "string",
+    baz: {
+      get: function(){
+        return this.foo;
+      }
+    }
+  });
+
+  var map = new MyMap({ foo: "bar" });
+
+  each(map, function(value, key){
+    QUnit.equal(key, "foo");
+    QUnit.equal(value, "bar");
+  });
 });

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "can-construct": "^3.0.0-pre.3",
     "can-event": "^3.0.0-pre.2",
     "can-observation": "^3.0.0-pre.4",
-    "can-util": "^3.0.0-pre.13"
+    "can-util": "^3.0.0-pre.35"
   },
   "devDependencies": {
     "can-list": "^3.0.0-pre.6",


### PR DESCRIPTION
This implements iterators for maps and other defined constructors so
that you can do:

```js
for(var [key, value] of map) {

}
```

In supporting browsers and:

```js
var each = require("can-util/js/each/each");

each(map, function(value, key){

});
```

In older browsers. This is a needed feature to make `{{#each map}}` work
in stache.

Closes #54