### PR TITLE
60 fix for concat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 doc/
 dist/
+.idea/

--- a/list/list-test.js
+++ b/list/list-test.js
@@ -108,6 +108,22 @@ test('Array accessor methods', 11, function () {
 		}
 	});
 });
+
+test('Concated list Equals original', function() {
+	var l = new DefineList([
+			{ firstProp: "Some data" },
+			{ secondProp: "Next data" }
+		]),
+		concatenated = l.concat([
+			{ hello: "World" },
+			{ foo: "Bar" }
+		]);
+
+	ok(l[0] === concatenated[0], "They are Equal");
+	ok(l[1] === concatenated[1], "They are Equal");
+
+});
+
 test('splice removes items in IE (#562)', function () {
 	var l = new DefineList(['a']);
 	l.splice(0, 1);

--- a/list/list-test.js
+++ b/list/list-test.js
@@ -109,7 +109,7 @@ test('Array accessor methods', 11, function () {
 	});
 });
 
-test('Concated list Equals original', function() {
+test('Concatenated list items Equal original', function() {
 	var l = new DefineList([
 			{ firstProp: "Some data" },
 			{ secondProp: "Next data" }
@@ -122,6 +122,32 @@ test('Concated list Equals original', function() {
 	ok(l[0] === concatenated[0], "They are Equal");
 	ok(l[1] === concatenated[1], "They are Equal");
 
+});
+
+test('Lists with maps concatenate properly', function() {
+	var Person = DefineMap.extend();
+	var People = DefineList.extend({
+		DefineMap: Person
+	},{});
+	var Genius = Person.extend();
+	var Animal = DefineMap.extend();
+
+	var me = new Person({ name: "John" });
+	var animal = new Animal({ name: "Tak" });
+	var genius = new Genius({ name: "Einstein" });
+	var hero = { name: "Ghandi" };
+
+	var people = new People([]);
+	var specialPeople = new People([
+		genius,
+		hero
+	]);
+
+	people = people.concat([me, animal, specialPeople], specialPeople, [1, 2], 3);
+
+	ok(people.attr('length') === 8, "List length is right");
+	ok(people[0] === me, "Map in list === vars created before concat");
+	ok(people[1] instanceof Person, "Animal got serialized to Person");
 });
 
 test('splice removes items in IE (#562)', function () {

--- a/list/list.js
+++ b/list/list.js
@@ -781,13 +781,6 @@ assign(DefineList.prototype, {
      * newList.get(); // ['Alice', 'Bob', 'Charlie', 'Daniel', 'Eve', {f: 'Francis'}]
      * ```
      */
-    // concat: function () {
-    //     var args = [];
-    //     each(makeArray(arguments), function (arg, i) {
-    //         args[i] = arg instanceof DefineList ? arg.get() : arg;
-    //     });
-    //     return new this.constructor(Array.prototype.concat.apply(this.get(), args));
-    // },
     concat: function() {
         var args = [],
           MapType = this.constructor.Map;

--- a/list/list.js
+++ b/list/list.js
@@ -781,12 +781,32 @@ assign(DefineList.prototype, {
      * newList.get(); // ['Alice', 'Bob', 'Charlie', 'Daniel', 'Eve', {f: 'Francis'}]
      * ```
      */
-    concat: function () {
-        var args = [];
-        each(makeArray(arguments), function (arg, i) {
-            args[i] = arg instanceof DefineList ? arg.get() : arg;
+    // concat: function () {
+    //     var args = [];
+    //     each(makeArray(arguments), function (arg, i) {
+    //         args[i] = arg instanceof DefineList ? arg.get() : arg;
+    //     });
+    //     return new this.constructor(Array.prototype.concat.apply(this.get(), args));
+    // },
+    concat: function() {
+        var args = [],
+          MapType = this.constructor.Map;
+
+        each(arguments, function(arg) {
+            if(types.isListLike(arg)) {
+                var arr = makeArray(arg);
+                if(arr && arr.serialize && (arr instanceof MapType)) {
+                    args.push.apply(args, new MapType(arr.serialize()));
+                } else {
+                    args.push.apply(args, arr);
+                }
+            }
+            else {
+                args.push.apply(args, arg);
+            }
         });
-        return new this.constructor(Array.prototype.concat.apply(this.get(), args));
+
+        return new this.constructor(Array.prototype.concat.apply(makeArray(this), args));
     },
 
     /**


### PR DESCRIPTION
Closes #60 

Makes concat behave as expected and reference objects passed as args so that `sourceList[ 0 ] === ( sourceList.concat( [] ) )[ 0 ];`.