### PR TITLE
Consistency of behaviors for passing null and undefined to type and Type

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -384,7 +384,7 @@ make = {
 				}
 			}
 			return function(newValue) {
-				if (newValue instanceof Type) {
+				if (newValue instanceof Type || newValue == null) {
 					return set.call(this, newValue);
 				} else {
 					return set.call(this, new Type(newValue));
@@ -711,6 +711,9 @@ define.types = {
 		return +(val);
 	},
 	'boolean': function(val) {
+		if(val == null) {
+			return val;
+		}
 		if (val === 'false' || val === '0' || !val) {
 			return false;
 		}

--- a/define-test.js
+++ b/define-test.js
@@ -809,7 +809,7 @@ test("type converters handle null and undefined in expected ways (1693)", functi
 
 	equal(t.number, undefined, "converted to number");
 
-	equal(t.boolean, false, "converted to boolean");
+	equal(t.boolean, undefined, "converted to boolean"); //Updated for canjs#2316
 
 	equal(t.htmlbool, false, "converted to htmlbool");
 
@@ -830,7 +830,7 @@ test("type converters handle null and undefined in expected ways (1693)", functi
 
 	equal(t.number, null, "converted to number");
 
-	equal(t.boolean, false, "converted to boolean");
+	equal(t.boolean, null, "converted to boolean"); //Updated for canjs#2316
 
 	equal(t.htmlbool, false, "converted to htmlbool");
 
@@ -1228,59 +1228,24 @@ QUnit.test("nullish values are not converted for type or Type", function(assert)
 	var Foo = function() {};
 
 	var MyMap = define.Constructor({
-		num: {
-			type: "number"
-		},
-		bool: {
-			type: "boolean"
-		},
-		str: {
-			type: "string"
-		},
-		date: {
-			type: "date"
-		},
 		map: {
 			Type: Foo
 		},
-		notype: {},
-		htmlbool: {
-			type: "htmlbool"
-		}
+		notype: {}
 	});
 
 	var vm = new MyMap({
-		num: 1,
-		bool: true,
-		htmlbool: "foo",
-		str: "foo",
-		date: Date.now(),
 		map: {},
 		notype: {}
 	});
 
 	// Sanity check
-	assert.equal(typeof vm.num, "number", "num is a Number");
-	assert.equal(typeof vm.bool, "boolean", "bool is a Boolean");
-	assert.equal(typeof vm.htmlbool, "boolean", "htmlbool is a Boolean");
-	assert.equal(typeof vm.str, "string", "str is a String");
-	assert.ok(vm.date instanceof Date, "date is a Date");
 	assert.ok(vm.map instanceof Foo, "map is another type");
 	assert.ok(vm.notype instanceof Object, "notype is an Object");
 
-	vm.num = null;
-	vm.bool = null;
-	vm.htmlbool = null;
-	vm.str = null;
-	vm.date = null;
 	vm.map = null;
 	vm.notype = null;
 
-	assert.equal(vm.num, null, "num is null");
-	assert.equal(vm.bool, null, "bool is null");
-	assert.equal(vm.htmlbool, false, "htmlbool is FALSE NOT NULL (this is the lone exception)");
-	assert.equal(vm.str, null, "str is null");
-	assert.equal(vm.date, null, "date is null");
 	assert.equal(vm.map, null, "map is null");
 	assert.equal(vm.map, null, "notype is null");
 });

--- a/define-test.js
+++ b/define-test.js
@@ -1222,3 +1222,65 @@ QUnit.test("Doesn't override types.iterator if already on the prototype", functi
     QUnit.equal(key, "it");
   });
 });
+
+QUnit.test("nullish values are not converted for type or Type", function(assert) {
+
+	var Foo = function() {};
+
+	var MyMap = define.Constructor({
+		num: {
+			type: "number"
+		},
+		bool: {
+			type: "boolean"
+		},
+		str: {
+			type: "string"
+		},
+		date: {
+			type: "date"
+		},
+		map: {
+			Type: Foo
+		},
+		notype: {},
+		htmlbool: {
+			type: "htmlbool"
+		}
+	});
+
+	var vm = new MyMap({
+		num: 1,
+		bool: true,
+		htmlbool: "foo",
+		str: "foo",
+		date: Date.now(),
+		map: {},
+		notype: {}
+	});
+
+	// Sanity check
+	assert.equal(typeof vm.num, "number", "num is a Number");
+	assert.equal(typeof vm.bool, "boolean", "bool is a Boolean");
+	assert.equal(typeof vm.htmlbool, "boolean", "htmlbool is a Boolean");
+	assert.equal(typeof vm.str, "string", "str is a String");
+	assert.ok(vm.date instanceof Date, "date is a Date");
+	assert.ok(vm.map instanceof Foo, "map is another type");
+	assert.ok(vm.notype instanceof Object, "notype is an Object");
+
+	vm.num = null;
+	vm.bool = null;
+	vm.htmlbool = null;
+	vm.str = null;
+	vm.date = null;
+	vm.map = null;
+	vm.notype = null;
+
+	assert.equal(vm.num, null, "num is null");
+	assert.equal(vm.bool, null, "bool is null");
+	assert.equal(vm.htmlbool, false, "htmlbool is FALSE NOT NULL (this is the lone exception)");
+	assert.equal(vm.str, null, "str is null");
+	assert.equal(vm.date, null, "date is null");
+	assert.equal(vm.map, null, "map is null");
+	assert.equal(vm.map, null, "notype is null");
+});

--- a/docs/TypeConstructor.md
+++ b/docs/TypeConstructor.md
@@ -15,8 +15,7 @@ prop: {
 ```    
 
 `Type` is called before [can-define.types.type] and before [can-define.types.set]. It checks if the incoming value
-is an [instanceof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) `Type`. If it is,
-it passed the original value through.  If not, it passes the original value to `new Type(originalValue)` and returns the
+is an [instanceof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) `Type`. If it is, or if it is `null` or `undefined`, it passes the original value through.  If not, it passes the original value to `new Type(originalValue)` and returns the
 new instance to be set.
 
 @signature `{propDefinition}`

--- a/docs/define.types.md
+++ b/docs/define.types.md
@@ -2,7 +2,7 @@
 @parent can-define.static
 Defines the type, initial value, and get, set, and serialize behavior for an
 observable property. All type converters leave `null` and `undefined` as is except for
-the `"boolean"` type converter.
+the `"htmlbool"` type converter.
 
 @option {function} observable The default type behavior. It converts plain Objects to
 [can-define/map/map DefineMaps] and plain Arrays to [can-define/list/list DefineLists]. Everything else is left as is.

--- a/list/list.js
+++ b/list/list.js
@@ -794,7 +794,6 @@ assign(DefineList.prototype, {
      * ```
      */
     concat: function() {
-        debugger;
         var args = [],
           MapType = this.constructor.DefineMap;
         // Go through each of the passed `arguments` and


### PR DESCRIPTION
Major changes in this PR:

* if `{type: "boolean"}`, `null` and `undefined` remain as is instead of being converted to false.  This makes the "boolean" type align with how numbers, strings, dates are treated.  However, `{type: "htmlbool"}` has not changed and will convert nullish values to `false`.

* Any `Type` conversion will treat `null` and `undefined` as is instead of creating a new instance.