### PR TITLE
Add test for get + serialize behavior

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -21,6 +21,11 @@ QUnit.test("basics", function(){
 
 QUnit.test("serialize works", function(){
     var Person = DefineMap.extend({
+        __v: {
+	    	value: 0,
+	    	type: 'number',
+	    	serialize: false
+        },
         first: "string",
         last: "string"
     });
@@ -30,8 +35,27 @@ QUnit.test("serialize works", function(){
 
     var people = new People([{first: "j", last: "m"}]);
     QUnit.deepEqual(people.serialize(), [{first: "j", last: "m"}]);
-
 });
+
+QUnit.test("get() works", function(){
+    var Person = DefineMap.extend({
+        __v: {
+	    	value: 0,
+	    	type: 'number',
+	    	serialize: false
+        },
+        first: "string",
+        last: "string"
+    });
+
+    var People = DefineList.extend({
+        "*": Person
+    });
+
+    var people = new People([{first: "j", last: "m"}]);
+    QUnit.deepEqual(people.get(), [{ __v: 0, first: "j", last: "m"}]);
+});
+
 
 QUnit.test("Extended Map with empty def converts to default Observables", function(){
     var School = DefineMap.extend({


### PR DESCRIPTION
Assuming `DefineMap.prototype.get()` was intended to perform identically to `can.Map.prototype.attr()`, then it should return a PJSO with the values of all enumerable props assigned. Instead, it is only returning all serializable props, essentially making this call signature identically to `DefineMap.prototype.serialize()`.

This PR is just for the test to demonstrate that this behavior is broken or has otherwise changed in a breaking way.