### PR TITLE
Improve assignment to/from DefineMaps by avoiding copying special keys.

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -64,7 +64,7 @@ module.exports = define = ns.define = function(objPrototype, defines, baseDefine
 	// for any value that has a default value.
 	replaceWith(objPrototype, "_data", function() {
 		var map = this;
-		var data = {};
+		var data = Object.create(null);
 		for (var prop in dataInitializers) {
 			replaceWith(data, prop, dataInitializers[prop].bind(map), true);
 		}
@@ -76,7 +76,7 @@ module.exports = define = ns.define = function(objPrototype, defines, baseDefine
 	// that will create the property's compute when read.
 	replaceWith(objPrototype, "_computed", function() {
 		var map = this;
-		var data = {};
+		var data = Object.create(null);
 		for (var prop in computedInitializers) {
 			replaceWith(data, prop, computedInitializers[prop].bind(map));
 		}
@@ -556,7 +556,7 @@ getDefinitionsAndMethods = function(defines, baseDefines) {
 		delete defines["*"];
 		defaultDefinition = getDefinitionOrMethod("*", defaults, {});
 	} else {
-		defaultDefinition = {};
+		defaultDefinition = Object.create(null);
 	}
 
 	eachPropertyDescriptor(defines, function( prop, propertyDescriptor ) {
@@ -647,12 +647,12 @@ delete eventsProto.one;
 
 define.setup = function(props, sealed) {
 	defineConfigurableAndNotEnumerable(this, "_cid");
-	defineConfigurableAndNotEnumerable(this, "__bindEvents", {});
+	defineConfigurableAndNotEnumerable(this, "__bindEvents", Object.create(null));
 	defineConfigurableAndNotEnumerable(this, "_bindings", 0);
 	/* jshint -W030 */
 	CID(this);
 	var definitions = this._define.definitions;
-	var instanceDefinitions = {};
+	var instanceDefinitions = Object.create(null);
 	var map = this;
 	each(props, function(value, prop){
 		if(definitions[prop]) {

--- a/can-define.js
+++ b/can-define.js
@@ -704,7 +704,6 @@ eventsProto.off = eventsProto.unbind = eventsProto.removeEventListener;
 delete eventsProto.one;
 
 define.setup = function(props, sealed) {
-	//defineConfigurableAndNotEnumerable(this, "_cid");
 	defineNotWritable(this, "__bindEvents", Object.create(null));
 	defineNotWritable(this, "constructor", this.constructor);
 	/* jshint -W030 */

--- a/can-define.js
+++ b/can-define.js
@@ -64,7 +64,7 @@ module.exports = define = ns.define = function(objPrototype, defines, baseDefine
 	// for any value that has a default value.
 	replaceWith(objPrototype, "_data", function() {
 		var map = this;
-		var data = Object.create(null);
+		var data = {};
 		for (var prop in dataInitializers) {
 			replaceWith(data, prop, dataInitializers[prop].bind(map), true);
 		}

--- a/can-define.js
+++ b/can-define.js
@@ -14,7 +14,6 @@ var isEmptyObject = require("can-util/js/is-empty-object/is-empty-object");
 var assign = require("can-util/js/assign/assign");
 var dev = require("can-util/js/dev/dev");
 var CID = require("can-cid");
-var CIDMap = require("can-util/js/cid-map/");
 var isPlainObject = require("can-util/js/is-plain-object/is-plain-object");
 var isArray = require("can-util/js/is-array/is-array");
 var types = require("can-types");
@@ -25,8 +24,6 @@ var ns = require("can-namespace");
 var eventsProto, define,
 	make, makeDefinition, replaceWith, getDefinitionsAndMethods,
 	isDefineType, getDefinitionOrMethod;
-
-var bindingsMap = new CIDMap();
 
 var defineConfigurableAndNotEnumerable = function(obj, prop, value) {
 	Object.defineProperty(obj, prop, {
@@ -54,37 +51,6 @@ var eachPropertyDescriptor = function(map, cb){
 	}
 };
 
-function defineBindings(obj) {
-	Object.defineProperty(obj, "_bindings", {
-		configurable: true,
-		enumerable: false,
-		get: function() {
-			return bindingsMap.get(this) || 0;
-		},
-		set: function(count) {
-			if(typeof count === "object" && typeof count.bindings === "number") {
-				if(count.bindings > 0) {
-					bindingsMap.set(this, count.bindings);
-				} else {
-					bindingsMap["delete"](this);
-				}
-			}
-		}
-	});
-}
-
-function setBindings(obj, count) {
-	obj._bindings = { bindings: count };
-}
-
-function incrementBindings(count) {
-	/* jshint validthis: true */
-	setBindings(this, (this._bindings || 0) + count);
-}
-function decrementBindings(count) {
-	/* jshint validthis: true */
-	setBindings(this, Math.max((this._bindings || 0) - count, 0));
-}
 
 module.exports = define = ns.define = function(objPrototype, defines, baseDefine) {
 	// default property definitions on _data
@@ -741,9 +707,6 @@ define.setup = function(props, sealed) {
 	//defineConfigurableAndNotEnumerable(this, "_cid");
 	defineNotWritable(this, "__bindEvents", Object.create(null));
 	defineNotWritable(this, "constructor", this.constructor);
-	defineConfigurableAndNotEnumerable(this, "_incrementBindings", incrementBindings);
-	defineConfigurableAndNotEnumerable(this, "_decrementBindings", decrementBindings);
-	defineBindings(this, 0);
 	/* jshint -W030 */
 	CID(this);
 	defineNotWritable(this, "_cid", this._cid);

--- a/define-helpers/define-helpers.js
+++ b/define-helpers/define-helpers.js
@@ -26,7 +26,7 @@ var defineHelpers = {
 	},
 	removeSpecialKeys: function(map) {
 		if(map) {
-			["_data", "constructor", "_cid", "_bindings", "__bindEvents"].forEach(function(key) {
+			["_data", "constructor", "_cid", "__bindEvents"].forEach(function(key) {
 				delete map[key];
 			});
 		}

--- a/define-helpers/define-helpers.js
+++ b/define-helpers/define-helpers.js
@@ -7,79 +7,87 @@ var canEvent = require("can-event");
 
 
 var hasMethod = function(obj, method){
-    return obj && typeof obj === "object" && (method in obj);
+	return obj && typeof obj === "object" && (method in obj);
 };
 
 var defineHelpers = {
-    extendedSetup: function(props){
-        assign(this, props);
-    },
-    toObject: function(map, props, where, Type){
-        if(props instanceof Type) {
-            props.each(function(value, prop){
-                where[prop] = value;
-            });
-            return where;
-        } else {
-            return props;
-        }
-    },
-    defineExpando: function(map, prop, value) {
-        // first check if it's already a constructor define
-        var constructorDefines = map._define.definitions;
-        if(constructorDefines && constructorDefines[prop]) {
-            return;
-        }
-        // next if it's already on this instances
-        var instanceDefines = map._instanceDefinitions;
-        if(!instanceDefines) {
-            instanceDefines = map._instanceDefinitions = {};
-        }
-        if(!instanceDefines[prop]) {
-            var defaultDefinition = map._define.defaultDefinition || {type: define.types.observable};
-            define.property(map, prop, defaultDefinition, {},{});
-            // possibly convert value to List or DefineMap
-            map._data[prop] = defaultDefinition.type ? defaultDefinition.type(value) : define.types.observable(value);
-            instanceDefines[prop] = defaultDefinition;
-            canBatch.start();
-            canEvent.dispatch.call(map, {
-                type: "__keys",
-                target: map
-            });
-            if(map._data[prop] !== undefined) {
-                canEvent.dispatch.call(map, {
-                    type: prop,
-                    target: map
-                },[map._data[prop], undefined]);
-            }
-            canBatch.stop();
-            return true;
-        }
-    },
-    // ## getValue
+	extendedSetup: function(props){
+		assign(this, props);
+	},
+	toObject: function(map, props, where, Type){
+		if(props instanceof Type) {
+			props.each(function(value, prop){
+				where[prop] = value;
+			});
+			return where;
+		} else {
+			return props;
+		}
+	},
+	removeSpecialKeys: function(map) {
+		if(map) {
+			["_data", "constructor", "_cid", "_bindings", "__bindEvents"].forEach(function(key) {
+				delete map[key];
+			});
+		}
+		return map;
+	},
+	defineExpando: function(map, prop, value) {
+		// first check if it's already a constructor define
+		var constructorDefines = map._define.definitions;
+		if(constructorDefines && constructorDefines[prop]) {
+			return;
+		}
+		// next if it's already on this instances
+		var instanceDefines = map._instanceDefinitions;
+		if(!instanceDefines) {
+			instanceDefines = map._instanceDefinitions = {};
+		}
+		if(!instanceDefines[prop]) {
+			var defaultDefinition = map._define.defaultDefinition || {type: define.types.observable};
+			define.property(map, prop, defaultDefinition, {},{});
+			// possibly convert value to List or DefineMap
+			map._data[prop] = defaultDefinition.type ? defaultDefinition.type(value) : define.types.observable(value);
+			instanceDefines[prop] = defaultDefinition;
+			canBatch.start();
+			canEvent.dispatch.call(map, {
+				type: "__keys",
+				target: map
+			});
+			if(map._data[prop] !== undefined) {
+				canEvent.dispatch.call(map, {
+					type: prop,
+					target: map
+				},[map._data[prop], undefined]);
+			}
+			canBatch.stop();
+			return true;
+		}
+	},
+	// ## getValue
 	// If `val` is an observable, calls `how` on it; otherwise
 	// returns the value of `val`.
 	getValue: function(map, name, val, how){
-        // check if there's a serialize
-        if(how === "serialize") {
-            var constructorDefinitions = map._define.definitions;
-            var propDef = constructorDefinitions[name];
-            if(propDef && typeof propDef.serialize === "function") {
-                return propDef.serialize.call(map, val, name);
-            }
-            var defaultDefinition = map._define.defaultDefinition;
-            if(defaultDefinition && typeof defaultDefinition.serialize === "function") {
-                return defaultDefinition.serialize.call(map, val, name);
-            }
-        }
+		// check if there's a serialize
+		if(how === "serialize") {
+			var constructorDefinitions = map._define.definitions;
+			var propDef = constructorDefinitions[name];
+			if(propDef && typeof propDef.serialize === "function") {
+				return propDef.serialize.call(map, val, name);
+			}
+			var defaultDefinition = map._define.defaultDefinition;
+			if(defaultDefinition && typeof defaultDefinition.serialize === "function") {
+				return defaultDefinition.serialize.call(map, val, name);
+			}
+		}
 
-        if( hasMethod(val, how) ) {
+		if( hasMethod(val, how) ) {
 			return val[how]();
 		} else {
 			return val;
 		}
 	},
-    // ### mapHelpers.serialize
+	// ### mapHelpers.serialize
 	// Serializes a Map or Map.List by recursively calling the `how`
 	// method on any child objects. This is able to handle
 	// cycles.
@@ -113,7 +121,7 @@ var defineHelpers = {
 			map.each(function (val, name) {
 				// If the value is an `object`, and has an `attr` or `serialize` function.
 
-                var result,
+				var result,
 					isObservable =   hasMethod(val, how),
 					serialized = isObservable && serializeMap[how][CID(val)];
 
@@ -124,9 +132,9 @@ var defineHelpers = {
 					result = defineHelpers.getValue(map, name, val, how);
 				}
 				// this is probably removable
-                if(result !== undefined) {
-                    where[name] = result;
-                }
+				if(result !== undefined) {
+					where[name] = result;
+				}
 
 
 			});

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -488,6 +488,33 @@ QUnit.test("copying from .set() excludes special keys", function() {
 
 });
 
+QUnit.test("copying with assign() excludes special keys", function() {
+
+	var a = {
+		_data: {},
+		constructor: function() {},
+		_bindings: 100,
+		__bindEvents: {},
+		_cid: "object0",
+		"foo": "bar",
+		"existing": "newVal"
+	};
+
+	var b = new DefineMap({
+		"existing": "oldVal"
+	});
+	assign(b, a);
+
+	QUnit.notEqual(a.constructor, b.constructor, "Constructor prop not copied");
+	QUnit.notEqual(a._data, b._data, "_data prop not copied");
+	QUnit.notEqual(a._bindings, b._bindings, "_bindings prop not copied");
+	QUnit.notEqual(a.__bindEvents, b.__bindEvents, "_bindEvents prop not copied");
+	QUnit.notEqual(a._cid, b._cid, "_cid prop not copied");
+	QUnit.equal(a.foo, b.foo, "New props copied");
+	QUnit.equal(a.existing, b.existing, "Existing props copied");
+
+});
+
 QUnit.test("shorthand getter setter (#56)", function(){
 
     var Person = DefineMap.extend({

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -19,139 +19,139 @@ var sealWorks = (function() {
 QUnit.module("can-define/map/map");
 
 QUnit.test("creating an instance", function(){
-    var map = new DefineMap({prop: "foo"});
-    map.on("prop", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "BAR");
-        QUnit.equal(oldVal, "foo");
-    });
+	var map = new DefineMap({prop: "foo"});
+	map.on("prop", function(ev, newVal, oldVal){
+		QUnit.equal(newVal, "BAR");
+		QUnit.equal(oldVal, "foo");
+	});
 
-    map.prop ="BAR";
+	map.prop ="BAR";
 });
 
 QUnit.test("creating an instance with nested prop", function(){
 
-    var map = new DefineMap({name: {first: "Justin"}});
+	var map = new DefineMap({name: {first: "Justin"}});
 
-    map.name.on("first", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "David");
-        QUnit.equal(oldVal, "Justin");
-    });
+	map.name.on("first", function(ev, newVal, oldVal){
+		QUnit.equal(newVal, "David");
+		QUnit.equal(oldVal, "Justin");
+	});
 
-    map.name.first ="David";
+	map.name.first ="David";
 });
 
 
 QUnit.test("extending", function(){
-    var MyMap = DefineMap.extend({
-        prop: {}
-    });
+	var MyMap = DefineMap.extend({
+		prop: {}
+	});
 
-    var map = new MyMap();
-    map.on("prop", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "BAR");
-        QUnit.equal(oldVal, undefined);
-    });
+	var map = new MyMap();
+	map.on("prop", function(ev, newVal, oldVal){
+		QUnit.equal(newVal, "BAR");
+		QUnit.equal(oldVal, undefined);
+	});
 
-    map.prop = "BAR";
+	map.prop = "BAR";
 });
 
 QUnit.test("loop only through defined serializable props", function(){
-    var MyMap = DefineMap.extend({
-        propA: {},
-        propB: {serialize: false},
-        propC: {
-            get: function(){
-                return this.propA;
-            }
-        }
-    });
-    var inst = new MyMap({propA: 1, propB: 2});
-    QUnit.deepEqual(Object.keys(inst.get()), ["propA"]);
+	var MyMap = DefineMap.extend({
+		propA: {},
+		propB: {serialize: false},
+		propC: {
+			get: function(){
+				return this.propA;
+			}
+		}
+	});
+	var inst = new MyMap({propA: 1, propB: 2});
+	QUnit.deepEqual(Object.keys(inst.get()), ["propA"]);
 
 });
 
 QUnit.test("get and set can setup expandos", function(){
-    var map = new DefineMap();
-    var oi = new Observation(function(){
-        return map.get("foo");
-    },null,{
-        updater: function(newVal){
-            QUnit.equal(newVal, "bar", "updated to bar");
-        }
-    });
-    oi.start();
+	var map = new DefineMap();
+	var oi = new Observation(function(){
+		return map.get("foo");
+	},null,{
+		updater: function(newVal){
+			QUnit.equal(newVal, "bar", "updated to bar");
+		}
+	});
+	oi.start();
 
-    map.set("foo","bar");
+	map.set("foo","bar");
 
 });
 
 QUnit.test("default settings", function(){
-    var MyMap = DefineMap.extend({
-        "*": "string",
-        foo: {}
-    });
+	var MyMap = DefineMap.extend({
+		"*": "string",
+		foo: {}
+	});
 
-    var m = new MyMap();
-    m.set("foo",123);
-    QUnit.ok(m.get("foo") === "123");
+	var m = new MyMap();
+	m.set("foo",123);
+	QUnit.ok(m.get("foo") === "123");
 
 });
 
 QUnit.test("default settings on unsealed", function(){
-    var MyMap = DefineMap.extend({
-        seal: false
-    },{
-        "*": "string"
-    });
+	var MyMap = DefineMap.extend({
+		seal: false
+	},{
+		"*": "string"
+	});
 
-    var m = new MyMap();
-    m.set("foo",123);
-    QUnit.ok(m.get("foo") === "123");
+	var m = new MyMap();
+	m.set("foo",123);
+	QUnit.ok(m.get("foo") === "123");
 
 });
 
 QUnit.test("get with dynamically added properties", function(){
-    var map = new DefineMap();
-    map.set("a",1);
-    map.set("b",2);
-    QUnit.deepEqual(map.get(), {a: 1, b:2});
+	var map = new DefineMap();
+	map.set("a",1);
+	map.set("b",2);
+	QUnit.deepEqual(map.get(), {a: 1, b:2});
 });
 
 
 QUnit.test("set multiple props", function(){
-    var map = new DefineMap();
-    map.set({a: 0, b: 2});
+	var map = new DefineMap();
+	map.set({a: 0, b: 2});
 
-    QUnit.deepEqual(map.get(), {a: 0, b:2});
+	QUnit.deepEqual(map.get(), {a: 0, b:2});
 
-    map.set({a: 2}, true);
+	map.set({a: 2}, true);
 
-    QUnit.deepEqual(map.get(), {a: 2});
+	QUnit.deepEqual(map.get(), {a: 2});
 
-    map.set({foo: {bar: "VALUE"}});
+	map.set({foo: {bar: "VALUE"}});
 
-    QUnit.deepEqual(map.get(), {foo: {bar: "VALUE"}, a: 2});
+	QUnit.deepEqual(map.get(), {foo: {bar: "VALUE"}, a: 2});
 });
 
 QUnit.test("serialize responds to added props", function(){
-    var map = new DefineMap();
-    var oi = new Observation(function(){
-        return map.serialize();
-    },null,{
-        updater: function(newVal){
-            QUnit.deepEqual(newVal, {a: 1, b: 2}, "updated right");
-        }
-    });
-    oi.start();
+	var map = new DefineMap();
+	var oi = new Observation(function(){
+		return map.serialize();
+	},null,{
+		updater: function(newVal){
+			QUnit.deepEqual(newVal, {a: 1, b: 2}, "updated right");
+		}
+	});
+	oi.start();
 
-    map.set({a: 1, b: 2});
+	map.set({a: 1, b: 2});
 });
 
 QUnit.test("initialize an undefined property", function(){
-    var MyMap = DefineMap.extend({seal: false},{});
-    var instance = new MyMap({foo:"bar"});
+	var MyMap = DefineMap.extend({seal: false},{});
+	var instance = new MyMap({foo:"bar"});
 
-    equal(instance.foo, "bar");
+	equal(instance.foo, "bar");
 });
 
 QUnit.test("set an already initialized null property", function(){
@@ -162,111 +162,111 @@ QUnit.test("set an already initialized null property", function(){
 });
 
 QUnit.test("creating a new key doesn't cause two changes", 1, function(){
-    var map = new DefineMap();
-    var oi = new Observation(function(){
-        return map.serialize();
-    },null,{
-        updater: function(newVal){
-            QUnit.deepEqual(newVal, {a: 1}, "updated right");
-        }
-    });
-    oi.start();
+	var map = new DefineMap();
+	var oi = new Observation(function(){
+		return map.serialize();
+	},null,{
+		updater: function(newVal){
+			QUnit.deepEqual(newVal, {a: 1}, "updated right");
+		}
+	});
+	oi.start();
 
-    map.set("a", 1);
+	map.set("a", 1);
 });
 
 QUnit.test("setting nested object", function(){
-    var m = new DefineMap({});
+	var m = new DefineMap({});
 
-    m.set({foo: {}});
-    m.set({foo: {}});
-    QUnit.deepEqual(m.get(), {foo: {}});
+	m.set({foo: {}});
+	m.set({foo: {}});
+	QUnit.deepEqual(m.get(), {foo: {}});
 });
 
 QUnit.test("passing a DefineMap to DefineMap (#33)", function(){
-    var MyMap = DefineMap.extend({foo: "observable"});
-    var m = new MyMap({foo: {}, bar: {}});
+	var MyMap = DefineMap.extend({foo: "observable"});
+	var m = new MyMap({foo: {}, bar: {}});
 
-    var m2 = new MyMap(m);
-    QUnit.deepEqual(m.get(), m2.get());
-    QUnit.ok(m.foo === m2.foo, "defined props the same");
-    QUnit.ok(m.bar === m2.bar, "expando props the same");
+	var m2 = new MyMap(m);
+	QUnit.deepEqual(m.get(), m2.get());
+	QUnit.ok(m.foo === m2.foo, "defined props the same");
+	QUnit.ok(m.bar === m2.bar, "expando props the same");
 
 });
 
 QUnit.test("serialize: function works (#38)", function(){
-    var Something = DefineMap.extend({});
+	var Something = DefineMap.extend({});
 
-    var MyMap = DefineMap.extend({
-        somethingRef: {
-            type: function(val){
-                return new Something({id: val});
-            },
-            serialize: function(val){
-                return val.id;
-            }
-        },
-        somethingElseRef: {
-            type: function(val){
-                return new Something({id: val});
-            },
-            serialize: false
-        }
-    });
+	var MyMap = DefineMap.extend({
+		somethingRef: {
+			type: function(val){
+				return new Something({id: val});
+			},
+			serialize: function(val){
+				return val.id;
+			}
+		},
+		somethingElseRef: {
+			type: function(val){
+				return new Something({id: val});
+			},
+			serialize: false
+		}
+	});
 
-    var myMap = new MyMap({somethingRef: 2, somethingElseRef: 3});
+	var myMap = new MyMap({somethingRef: 2, somethingElseRef: 3});
 
-    QUnit.ok(myMap.somethingRef instanceof Something);
-    QUnit.deepEqual( myMap.serialize(), {somethingRef: 2}, "serialize: function and serialize: false works");
+	QUnit.ok(myMap.somethingRef instanceof Something);
+	QUnit.deepEqual( myMap.serialize(), {somethingRef: 2}, "serialize: function and serialize: false works");
 
 
-    var MyMap2 = DefineMap.extend({
-        "*": {
-            serialize: function(value){
-                return ""+value;
-            }
-        }
-    });
+	var MyMap2 = DefineMap.extend({
+		"*": {
+			serialize: function(value){
+				return ""+value;
+			}
+		}
+	});
 
-    var myMap2 = new MyMap2({foo: 1, bar: 2});
-    QUnit.deepEqual( myMap2.serialize(), {foo: "1", bar: "2"}, "serialize: function on default works");
+	var myMap2 = new MyMap2({foo: 1, bar: 2});
+	QUnit.deepEqual( myMap2.serialize(), {foo: "1", bar: "2"}, "serialize: function on default works");
 
 });
 
 QUnit.test("isMapLike", function(){
-    var map = new DefineMap({});
-    ok(canTypes.isMapLike(map), "is map like");
+	var map = new DefineMap({});
+	ok(canTypes.isMapLike(map), "is map like");
 });
 
 QUnit.test("get will not create properties", function(){
-    var method = function(){};
-    var MyMap = DefineMap.extend({
-        method: method
-    });
-    var m = new MyMap();
-    m.get("foo");
+	var method = function(){};
+	var MyMap = DefineMap.extend({
+		method: method
+	});
+	var m = new MyMap();
+	m.get("foo");
 
-    QUnit.equal(m.get("method"), method);
+	QUnit.equal(m.get("method"), method);
 });
 
 QUnit.test("Properties are enumerable", function(){
   QUnit.expect(4);
 
   var VM = DefineMap.extend({
-    foo: "string"
+	foo: "string"
   });
   var vm = new VM({ foo: "bar", baz: "qux" });
 
   var i = 0;
   each(vm, function(value, key){
-    if(i === 0) {
-      QUnit.equal(key, "foo");
-      QUnit.equal(value, "bar");
-    } else {
-      QUnit.equal(key, "baz");
-      QUnit.equal(value, "qux");
-    }
-    i++;
+	if(i === 0) {
+	  QUnit.equal(key, "foo");
+	  QUnit.equal(value, "bar");
+	} else {
+	  QUnit.equal(key, "baz");
+	  QUnit.equal(value, "qux");
+	}
+	i++;
   });
 });
 
@@ -274,116 +274,162 @@ QUnit.test("Getters are not enumerable", function(){
   QUnit.expect(2);
 
   var MyMap = DefineMap.extend({
-    foo: "string",
-    baz: {
-      get: function(){
-        return this.foo;
-      }
-    }
+	foo: "string",
+	baz: {
+	  get: function(){
+		return this.foo;
+	  }
+	}
   });
 
   var map = new MyMap({ foo: "bar" });
 
   each(map, function(value, key){
-    QUnit.equal(key, "foo");
-    QUnit.equal(value, "bar");
+	QUnit.equal(key, "foo");
+	QUnit.equal(value, "bar");
   });
 });
 
 QUnit.test("extending DefineMap constructor functions (#18)", function(){
-    var AType = DefineMap.extend("AType", { aProp: {}, aMethod: function(){} });
+	var AType = DefineMap.extend("AType", { aProp: {}, aMethod: function(){} });
 
-    var BType = AType.extend("BType", { bProp: {}, bMethod: function(){} });
+	var BType = AType.extend("BType", { bProp: {}, bMethod: function(){} });
 
-    var CType = BType.extend("CType", { cProp: {}, cMethod: function(){} });
+	var CType = BType.extend("CType", { cProp: {}, cMethod: function(){} });
 
-    var map = new CType();
+	var map = new CType();
 
-    map.on("aProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "PROP");
-        QUnit.equal(oldVal, undefined);
-    });
-    map.on("bProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "FOO");
-        QUnit.equal(oldVal, undefined);
-    });
-    map.on("cProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "BAR");
-        QUnit.equal(oldVal, undefined);
-    });
+	map.on("aProp", function(ev, newVal, oldVal){
+		QUnit.equal(newVal, "PROP");
+		QUnit.equal(oldVal, undefined);
+	});
+	map.on("bProp", function(ev, newVal, oldVal){
+		QUnit.equal(newVal, "FOO");
+		QUnit.equal(oldVal, undefined);
+	});
+	map.on("cProp", function(ev, newVal, oldVal){
+		QUnit.equal(newVal, "BAR");
+		QUnit.equal(oldVal, undefined);
+	});
 
-    map.aProp = "PROP";
-    map.bProp = 'FOO';
-    map.cProp = 'BAR';
-    QUnit.ok(map.aMethod);
-    QUnit.ok(map.bMethod);
-    QUnit.ok(map.cMethod);
+	map.aProp = "PROP";
+	map.bProp = 'FOO';
+	map.cProp = 'BAR';
+	QUnit.ok(map.aMethod);
+	QUnit.ok(map.bMethod);
+	QUnit.ok(map.cMethod);
 });
 
 QUnit.test("extending DefineMap constructor functions more than once (#18)", function(){
-    var AType = DefineMap.extend("AType", { aProp: {}, aMethod: function(){} });
+	var AType = DefineMap.extend("AType", { aProp: {}, aMethod: function(){} });
 
-    var BType = AType.extend("BType", { bProp: {}, bMethod: function(){} });
+	var BType = AType.extend("BType", { bProp: {}, bMethod: function(){} });
 
-    var CType = AType.extend("CType", { cProp: {}, cMethod: function(){} });
+	var CType = AType.extend("CType", { cProp: {}, cMethod: function(){} });
 
-    var map1 = new BType();
-    var map2 = new CType();
+	var map1 = new BType();
+	var map2 = new CType();
 
-    map1.on("aProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "PROP", "aProp newVal on map1");
-        QUnit.equal(oldVal, undefined);
-    });
-    map1.on("bProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "FOO", "bProp newVal on map1");
-        QUnit.equal(oldVal, undefined);
-    });
+	map1.on("aProp", function(ev, newVal, oldVal){
+		QUnit.equal(newVal, "PROP", "aProp newVal on map1");
+		QUnit.equal(oldVal, undefined);
+	});
+	map1.on("bProp", function(ev, newVal, oldVal){
+		QUnit.equal(newVal, "FOO", "bProp newVal on map1");
+		QUnit.equal(oldVal, undefined);
+	});
 
-    map2.on("aProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "PROP", "aProp newVal on map2");
-        QUnit.equal(oldVal, undefined);
-    });
-    map2.on("cProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "BAR", "cProp newVal on map2");
-        QUnit.equal(oldVal, undefined);
-    });
+	map2.on("aProp", function(ev, newVal, oldVal){
+		QUnit.equal(newVal, "PROP", "aProp newVal on map2");
+		QUnit.equal(oldVal, undefined);
+	});
+	map2.on("cProp", function(ev, newVal, oldVal){
+		QUnit.equal(newVal, "BAR", "cProp newVal on map2");
+		QUnit.equal(oldVal, undefined);
+	});
 
-    map1.aProp = "PROP";
-    map1.bProp = 'FOO';
-    map2.aProp = "PROP";
-    map2.cProp = 'BAR';
-    QUnit.ok(map1.aMethod, "map1 aMethod");
-    QUnit.ok(map1.bMethod);
-    QUnit.ok(map2.aMethod);
-    QUnit.ok(map2.cMethod, "map2 cMethod");
+	map1.aProp = "PROP";
+	map1.bProp = 'FOO';
+	map2.aProp = "PROP";
+	map2.cProp = 'BAR';
+	QUnit.ok(map1.aMethod, "map1 aMethod");
+	QUnit.ok(map1.bMethod);
+	QUnit.ok(map2.aMethod);
+	QUnit.ok(map2.cMethod, "map2 cMethod");
 });
 
 QUnit.test("extending DefineMap constructor functions - value (#18)", function(){
-    var AType = DefineMap.extend("AType", { aProp: {value: 1} });
+	var AType = DefineMap.extend("AType", { aProp: {value: 1} });
 
-    var BType = AType.extend("BType", { });
+	var BType = AType.extend("BType", { });
 
-    var CType = BType.extend("CType",{ });
+	var CType = BType.extend("CType",{ });
 
-    var c = new CType();
-    QUnit.equal( c.aProp , 1 ,"got initial value" );
+	var c = new CType();
+	QUnit.equal( c.aProp , 1 ,"got initial value" );
 });
 
 QUnit.test("copying DefineMap excludes constructor", function() {
 
-    var AType = DefineMap.extend("AType", { aProp: {value: 1} });
+	var AType = DefineMap.extend("AType", { aProp: {value: 1} });
 
-    var a = new AType();
+	var a = new AType();
 
-    var b = assign({}, a);
+	var b = assign({}, a);
 
-    QUnit.notEqual(a.constructor, b.constructor, "Constructor prop not copied");
-    QUnit.equal(a.aProp, b.aProp, "Other values are unaffected");
+	QUnit.notEqual(a.constructor, b.constructor, "Constructor prop not copied");
+	QUnit.equal(a.aProp, b.aProp, "Other values are unaffected");
 
 });
+
+QUnit.test("cloning from non-defined map excludes special keys on setup", function() {
+
+	var a = {
+		_data: {},
+		constructor: function() {},
+		_bindings: -100,
+		_bindEvents: {},
+		_cid: "object0",
+		"foo": "bar"
+	};
+
+	var b = new DefineMap(a);
+
+	QUnit.notEqual(a.constructor, b.constructor, "Constructor prop not copied");
+	QUnit.notEqual(a._data, b._data, "_data prop not copied");
+	QUnit.notEqual(a._bindings, b._bindings, "_bindings prop not copied");
+	QUnit.notEqual(a._bindEvents, b._bindEvents, "_bindEvents prop not copied");
+	QUnit.notEqual(a._cid, b._cid, "_cid prop not copied");
+	QUnit.equal(a.foo, b.foo, "Other props copied");
+
+});
+
+QUnit.test("copying from .set() excludes special keys", function() {
+
+	var a = {
+		_data: {},
+		constructor: function() {},
+		_bindings: -100,
+		_bindEvents: {},
+		_cid: "object0",
+		"foo": "bar"
+	};
+
+	var b = new DefineMap();
+	b.set(a);
+
+	QUnit.notEqual(a.constructor, b.constructor, "Constructor prop not copied");
+	QUnit.notEqual(a._data, b._data, "_data prop not copied");
+	QUnit.notEqual(a._bindings, b._bindings, "_bindings prop not copied");
+	QUnit.notEqual(a._bindEvents, b._bindEvents, "_bindEvents prop not copied");
+	QUnit.notEqual(a._cid, b._cid, "_cid prop not copied");
+	QUnit.equal(a.foo, b.foo, "Other props copied");
+
+});
+
 QUnit.test("shorthand getter setter (#56)", function(){
 
-    var Person = DefineMap.extend({
+	var Person = DefineMap.extend({
 		first: "*",
 		last: "*",
 		get fullName() {
@@ -422,32 +468,32 @@ QUnit.test('compute props can be set to null or undefined (#2372)', function() {
 });
 
 QUnit.test("Inheriting DefineMap .set doesn't work if prop is on base map (#74)", function(){
-    var Base = DefineMap.extend({
-        baseProp: "string"
-    });
+	var Base = DefineMap.extend({
+		baseProp: "string"
+	});
 
-    var Inheriting = Base.extend();
+	var Inheriting = Base.extend();
 
-    var inherting = new Inheriting();
+	var inherting = new Inheriting();
 
-    inherting.set("baseProp", "value");
+	inherting.set("baseProp", "value");
 
 
-    QUnit.equal(inherting.baseProp,"value", "set prop");
+	QUnit.equal(inherting.baseProp,"value", "set prop");
 });
 
 if(sealWorks && System.env.indexOf('production') < 0) {
 	QUnit.test("setting not defined property", function(){
-	    var MyMap = DefineMap.extend({
-	        prop: {}
-	    });
-	    var mymap = new MyMap();
+		var MyMap = DefineMap.extend({
+			prop: {}
+		});
+		var mymap = new MyMap();
 
-	    try {
-	        mymap.notdefined = "value";
-	        ok(false, "no error");
-	    } catch(e) {
-	        ok(true, "error thrown");
-	    }
+		try {
+			mymap.notdefined = "value";
+			ok(false, "no error");
+		} catch(e) {
+			ok(true, "error thrown");
+		}
 	});
 }

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -4,6 +4,7 @@ var DefineMap = require("can-define/map/map");
 var Observation = require("can-observation");
 var canTypes = require("can-util/js/types/types");
 var each = require("can-util/js/each/each");
+var assign = require("can-util/js/assign/assign");
 var sealWorks = (function() {
 	try {
 		var o = {};
@@ -368,6 +369,18 @@ QUnit.test("extending DefineMap constructor functions - value (#18)", function()
     QUnit.equal( c.aProp , 1 ,"got initial value" );
 });
 
+QUnit.test("copying DefineMap excludes constructor", function() {
+
+    var AType = DefineMap.extend("AType", { aProp: {value: 1} });
+
+    var a = new AType();
+
+    var b = assign({}, a);
+
+    QUnit.notEqual(a.constructor, b.constructor, "Constructor prop not copied");
+    QUnit.equal(a.aProp, b.aProp, "Other values are unaffected");
+
+});
 QUnit.test("shorthand getter setter (#56)", function(){
 
     var Person = DefineMap.extend({

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -448,7 +448,6 @@ QUnit.test("cloning from non-defined map excludes special keys on setup", functi
 	var a = {
 		_data: {},
 		constructor: function() {},
-		_bindings: -100,
 		_bindEvents: {},
 		_cid: "object0",
 		"foo": "bar"
@@ -458,7 +457,6 @@ QUnit.test("cloning from non-defined map excludes special keys on setup", functi
 
 	QUnit.notEqual(a.constructor, b.constructor, "Constructor prop not copied");
 	QUnit.notEqual(a._data, b._data, "_data prop not copied");
-	QUnit.notEqual(a._bindings, b._bindings, "_bindings prop not copied");
 	QUnit.notEqual(a._bindEvents, b._bindEvents, "_bindEvents prop not copied");
 	QUnit.notEqual(a._cid, b._cid, "_cid prop not copied");
 	QUnit.equal(a.foo, b.foo, "Other props copied");
@@ -470,21 +468,22 @@ QUnit.test("copying from .set() excludes special keys", function() {
 	var a = {
 		_data: {},
 		constructor: function() {},
-		_bindings: -100,
 		_bindEvents: {},
 		_cid: "object0",
-		"foo": "bar"
+		"foo": "bar",
+		"existing": "newVal"
 	};
 
-	var b = new DefineMap();
+	var b = new DefineMap({
+		"existing": "oldVal"
+	});
 	b.set(a);
 
 	QUnit.notEqual(a.constructor, b.constructor, "Constructor prop not copied");
 	QUnit.notEqual(a._data, b._data, "_data prop not copied");
-	QUnit.notEqual(a._bindings, b._bindings, "_bindings prop not copied");
 	QUnit.notEqual(a._bindEvents, b._bindEvents, "_bindEvents prop not copied");
 	QUnit.notEqual(a._cid, b._cid, "_cid prop not copied");
-	QUnit.equal(a.foo, b.foo, "Other props copied");
+	QUnit.equal(a.foo, b.foo, "NEw props copied");
 
 });
 
@@ -493,7 +492,6 @@ QUnit.test("copying with assign() excludes special keys", function() {
 	var a = {
 		_data: {},
 		constructor: function() {},
-		_bindings: 100,
 		__bindEvents: {},
 		_cid: "object0",
 		"foo": "bar",
@@ -507,12 +505,11 @@ QUnit.test("copying with assign() excludes special keys", function() {
 
 	QUnit.notEqual(a.constructor, b.constructor, "Constructor prop not copied");
 	QUnit.notEqual(a._data, b._data, "_data prop not copied");
-	QUnit.notEqual(a._bindings, b._bindings, "_bindings prop not copied");
 	QUnit.notEqual(a.__bindEvents, b.__bindEvents, "_bindEvents prop not copied");
 	QUnit.notEqual(a._cid, b._cid, "_cid prop not copied");
 	QUnit.equal(a.foo, b.foo, "New props copied");
 	QUnit.equal(a.existing, b.existing, "Existing props copied");
-
+	
 });
 
 QUnit.test("shorthand getter setter (#56)", function(){

--- a/map/map.js
+++ b/map/map.js
@@ -29,7 +29,7 @@ var eachDefinition = function(map, cb, thisarg, definitions, observe) {
 };
 
 var setProps = function(props, remove) {
-	props = assign({}, props);
+	props = defineHelpers.removeSpecialKeys(assign({}, props));
 	var prop,
 		self = this,
 		newVal;
@@ -92,7 +92,11 @@ var DefineMap = Construct.extend("DefineMap",{
 			}
 
 			this.prototype.setup = function(props){
-				define.setup.call(this, defineHelpers.toObject(this, props,{}, DefineMap), this.constructor.seal);
+				define.setup.call(
+					this, 
+					defineHelpers.removeSpecialKeys(defineHelpers.toObject(this, props,{}, DefineMap)),
+					this.constructor.seal
+				);
 			};
 		} else {
 			for(key in prototype) {
@@ -116,7 +120,11 @@ var DefineMap = Construct.extend("DefineMap",{
 				value: {}
 			});
 		}
-		define.setup.call(this, defineHelpers.toObject(this, props,{}, DefineMap), sealed === true);
+		define.setup.call(
+			this,
+			defineHelpers.removeSpecialKeys(defineHelpers.toObject(this, props,{}, DefineMap)),
+			sealed === true
+		);
 	},
 	/**
 	 * @function can-define/map/map.prototype.get get

--- a/map/map.js
+++ b/map/map.js
@@ -10,267 +10,276 @@ var canBatch = require("can-event/batch/batch");
 var ns = require("can-util/namespace");
 
 var readWithoutObserve = Observation.ignore(function(map, prop){
-    return map[prop];
+	return map[prop];
 });
 
 var eachDefinition = function(map, cb, thisarg, definitions, observe) {
 
-    for(var prop in definitions) {
-        var definition = definitions[prop];
-        if(typeof definition !== "object" || ("serialize" in definition ? !!definition.serialize : !definition.get)) {
+	for(var prop in definitions) {
+		var definition = definitions[prop];
+		if(typeof definition !== "object" || ("serialize" in definition ? !!definition.serialize : !definition.get)) {
 
-            var item = observe === false ? readWithoutObserve(map, prop) : map[prop];
+			var item = observe === false ? readWithoutObserve(map, prop) : map[prop];
 
-            if (cb.call(thisarg || item, item, prop, map) === false) {
-                return false;
-            }
-        }
-    }
+			if (cb.call(thisarg || item, item, prop, map) === false) {
+				return false;
+			}
+		}
+	}
 };
 
 var setProps = function(props, remove) {
-    props = assign({}, props);
-    var prop,
-        self = this,
-        newVal;
+	props = assign({}, props);
+	var prop,
+		self = this,
+		newVal;
 
-    // Batch all of the change events until we are done.
-    canBatch.start();
-    // Merge current properties with the new ones.
-    this.each(function(curVal, prop) {
-        // You can not have a _cid property; abort.
-        if (prop === "_cid") {
-            return;
-        }
-        newVal = props[prop];
+	// Batch all of the change events until we are done.
+	canBatch.start();
+	// Merge current properties with the new ones.
+	this.each(function(curVal, prop) {
+		// You can not have a _cid property; abort.
+		if (prop === "_cid") {
+			return;
+		}
+		newVal = props[prop];
 
-        // If we are merging, remove the property if it has no value.
-        if (newVal === undefined) {
-            if (remove) {
-                self[prop] = undefined;
-            }
-            return;
-        }
-        if( typeof curVal !== "object" || curVal === null ) {
-            self.set(prop, newVal);
-        }
-        else if( ("set" in curVal) && isPlainObject(newVal) ) {
-            curVal.set(newVal, remove);
-        }
-        else if( ("attr" in curVal) && (isPlainObject(newVal) || isArray(newVal)) ) {
-            curVal.attr(newVal, remove);
-        }
-        else if("replace" in curVal && isArray(newVal)) {
-            curVal.replace(newVal);
-        }
-        else if(curVal !== newVal) {
-            self.set(prop, newVal);
-        }
-        delete props[prop];
-    }, this, false);
-    // Add remaining props.
-    for (prop in props) {
-        // Ignore _cid.
-        if (prop !== "_cid") {
-            newVal = props[prop];
-            this.set(prop, newVal);
-        }
+		// If we are merging, remove the property if it has no value.
+		if (newVal === undefined) {
+			if (remove) {
+				self[prop] = undefined;
+			}
+			return;
+		}
+		if( typeof curVal !== "object" || curVal === null ) {
+			self.set(prop, newVal);
+		}
+		else if( ("set" in curVal) && isPlainObject(newVal) ) {
+			curVal.set(newVal, remove);
+		}
+		else if( ("attr" in curVal) && (isPlainObject(newVal) || isArray(newVal)) ) {
+			curVal.attr(newVal, remove);
+		}
+		else if("replace" in curVal && isArray(newVal)) {
+			curVal.replace(newVal);
+		}
+		else if(curVal !== newVal) {
+			self.set(prop, newVal);
+		}
+		delete props[prop];
+	}, this, false);
+	// Add remaining props.
+	for (prop in props) {
+		// Ignore _cid.
+		if (prop !== "_cid") {
+			newVal = props[prop];
+			this.set(prop, newVal);
+		}
 
-    }
-    canBatch.stop();
-    return this;
+	}
+	canBatch.stop();
+	return this;
 };
 
 var DefineMap = Construct.extend("DefineMap",{
-    setup: function(base){
-        if(DefineMap) {
-            var prototype = this.prototype;
-            define(prototype, prototype, base.prototype._define);
+	setup: function(base){
+		var key,
+			prototype = this.prototype;
+		if(DefineMap) {
+			define(prototype, prototype, base.prototype._define);
+			for(key in DefineMap.prototype) {
+				define.defineConfigurableAndNotEnumerable(prototype, key, prototype[key]);
+			}
 
-            this.prototype.setup = function(props){
-                define.setup.call(this, defineHelpers.toObject(this, props,{}, DefineMap), this.constructor.seal);
-            };
-        }
-    }
+			this.prototype.setup = function(props){
+				define.setup.call(this, defineHelpers.toObject(this, props,{}, DefineMap), this.constructor.seal);
+			};
+		} else {
+			for(key in prototype) {
+				define.defineConfigurableAndNotEnumerable(prototype, key, prototype[key]);
+			}			
+		}
+		define.defineConfigurableAndNotEnumerable(prototype, "constructor", this);
+	}
 },{
-    // setup for only dynamic DefineMap instances
-    setup: function(props, sealed){
-        if(!this._define) {
-            Object.defineProperty(this,"_define",{
-                enumerable: false,
-                value: {
-                    definitions: {}
-                }
-            });
-            Object.defineProperty(this,"_data",{
-                enumerable: false,
-                value: {}
-            });
-        }
-        define.setup.call(this, defineHelpers.toObject(this, props,{}, DefineMap), sealed === true);
-    },
-    /**
-     * @function can-define/map/map.prototype.get get
-     * @parent can-define/map/map.prototype
-     *
-     * @description Get a value or all values from a DefineMap.
-     *
-     * @signature `map.get()`
-     *
-     * Returns a plain JavaScript object that contains the properties and values of the map instance.  Any property values
-     * that also have a `get` method will have their `get` method called and the resulting value will be used as
-     * the property value.  This can be used to recursively convert a map instance to an object of other plain
-     * JavaScript objects.  Cycles are supported and only create one object.
-     *
-     * `.get()` can still return other non plain JS objects like Date.
-     * Use [can-define/map/map.prototype.serialize] when a form proper for `JSON.stringify` is needed.
-     *
-     * ```js
-     * var map = new DefineMap({foo: new DefineMap({bar: "zed"})});
-     * map.get() //-> {foo: {bar: "zed"}};
-     * ```
-     *
-     *   @return {Object} A plain JavaScript `Object` that contains all the properties and values of the map instance.
-     *
-     * @signature `map.get(propName)`
-     *
-     * Get a single property on a DefineMap instance.
-     *
-     * `.get(propName)` only should be used when reading properties that might not have been defined yet, but
-     * will be later via [can-define/map/map.prototype.set].
-     *
-     * ```js
-     * var map = new DefineMap();
-     * map.get("name") //-> undefined;
-     * ```
-     *
-     *   @param {String} propName The property name of a property that may not have been defined yet.
-     *   @return {*} The value of that property.
-     */
-    get: function(prop){
-        if(prop) {
-            var value = this[prop];
-            if(value !== undefined || prop in this || Object.isSealed(this)) {
-                return value;
-            } else {
-                Observation.add(this, prop);
-                return this[prop];
-            }
+	// setup for only dynamic DefineMap instances
+	setup: function(props, sealed){
+		if(!this._define) {
+			Object.defineProperty(this,"_define",{
+				enumerable: false,
+				value: {
+					definitions: {}
+				}
+			});
+			Object.defineProperty(this,"_data",{
+				enumerable: false,
+				value: {}
+			});
+		}
+		define.setup.call(this, defineHelpers.toObject(this, props,{}, DefineMap), sealed === true);
+	},
+	/**
+	 * @function can-define/map/map.prototype.get get
+	 * @parent can-define/map/map.prototype
+	 *
+	 * @description Get a value or all values from a DefineMap.
+	 *
+	 * @signature `map.get()`
+	 *
+	 * Returns a plain JavaScript object that contains the properties and values of the map instance.  Any property values
+	 * that also have a `get` method will have their `get` method called and the resulting value will be used as
+	 * the property value.  This can be used to recursively convert a map instance to an object of other plain
+	 * JavaScript objects.  Cycles are supported and only create one object.
+	 *
+	 * `.get()` can still return other non plain JS objects like Date.
+	 * Use [can-define/map/map.prototype.serialize] when a form proper for `JSON.stringify` is needed.
+	 *
+	 * ```js
+	 * var map = new DefineMap({foo: new DefineMap({bar: "zed"})});
+	 * map.get() //-> {foo: {bar: "zed"}};
+	 * ```
+	 *
+	 *   @return {Object} A plain JavaScript `Object` that contains all the properties and values of the map instance.
+	 *
+	 * @signature `map.get(propName)`
+	 *
+	 * Get a single property on a DefineMap instance.
+	 *
+	 * `.get(propName)` only should be used when reading properties that might not have been defined yet, but
+	 * will be later via [can-define/map/map.prototype.set].
+	 *
+	 * ```js
+	 * var map = new DefineMap();
+	 * map.get("name") //-> undefined;
+	 * ```
+	 *
+	 *   @param {String} propName The property name of a property that may not have been defined yet.
+	 *   @return {*} The value of that property.
+	 */
+	get: function(prop){
+		if(prop) {
+			var value = this[prop];
+			if(value !== undefined || prop in this || Object.isSealed(this)) {
+				return value;
+			} else {
+				Observation.add(this, prop);
+				return this[prop];
+			}
 
-        } else {
-            return defineHelpers.serialize(this, 'get', {});
-        }
-    },
-    /**
-     * @function can-define/map/map.prototype.set set
-     * @parent can-define/map/map.prototype
-     *
-     * @description Sets multiple properties on a map instance or a property that wasn't predefined.
-     *
-     * @signature `map.set(props [,removeProps])`
-     *
-     * Assigns each value in `props` to a property on this map instance named after the
-     * corresponding key in `props`, effectively merging `props` into the Map. If `removeProps` is true, properties not in
-     * `props` will be set to `undefined`.
-     *
-     *   @param {Object} props A collection of key-value pairs to set.
-     *   If any properties already exist on the map, they will be overwritten.
-     *
-     *   @param {Boolean} [removeProps=false] Whether to set keys not present in `props` to `undefined`.
-     *
-     *   @return {can-define/map/map} The map instance for chaining.
-     *
-     * @signature `map.set(propName, value)`
-     *
-     * Assigns _value_ to a property on this map instance called _propName_.  This will define
-     * the property if it hasn't already been predefined.
-     *
-     *   @param {String} propName The property to set.
-     *   @param {*} value The value to assign to `propName`.
-     *   @return {can-define/map/map} This map instance, for chaining.
-     */
-    set: function(prop, value){
-        if(typeof prop === "object") {
-            return setProps.call(this, prop, value);
-        }
-        var defined = defineHelpers.defineExpando(this, prop, value);
-        if(!defined) {
-            this[prop] = value;
-        }
-        return this;
-    },
-    /**
-     * @function can-define/map/map.prototype.serialize serialize
-     * @parent can-define/map/map.prototype
-     *
-     * @description Get a serialized representation of the map instance and its children.
-     *
-     * @signature `map.serialize()`
-     *
-     * Get the serialized Object form of the map.  Serialized
-     * data is typically used to send back to a server.  Use [can-define.types.serialize]
-     * to customize a property's serialized value or if the property should be added to
-     * the result or not.
-     *
-     * `undefined` serialized values are not added to the result.
-     *
-     * ```js
-     * var MyMap = DefineMap.extend({
-     *   date: {
-     *     type: "date",
-     *     serialize: function(date){
-     *       return date.getTime()
-     *     }
-     *   }
-     * });
-     *
-     * var myMap = new MyMap({date: new Date(), count: 5});
-     * myMap.serialize() //-> {date: 1469566698504, count: 5}
-     * ```
-     *
-     *   @return {Object} A JavaScript Object that can be serialized with `JSON.stringify` or other methods.
-     *
-     */
-    serialize: function () {
-        return defineHelpers.serialize(this, 'serialize', {});
-    },
+		} else {
+			return defineHelpers.serialize(this, 'get', {});
+		}
+	},
+	/**
+	 * @function can-define/map/map.prototype.set set
+	 * @parent can-define/map/map.prototype
+	 *
+	 * @description Sets multiple properties on a map instance or a property that wasn't predefined.
+	 *
+	 * @signature `map.set(props [,removeProps])`
+	 *
+	 * Assigns each value in `props` to a property on this map instance named after the
+	 * corresponding key in `props`, effectively merging `props` into the Map. If `removeProps` is true, properties not in
+	 * `props` will be set to `undefined`.
+	 *
+	 *   @param {Object} props A collection of key-value pairs to set.
+	 *   If any properties already exist on the map, they will be overwritten.
+	 *
+	 *   @param {Boolean} [removeProps=false] Whether to set keys not present in `props` to `undefined`.
+	 *
+	 *   @return {can-define/map/map} The map instance for chaining.
+	 *
+	 * @signature `map.set(propName, value)`
+	 *
+	 * Assigns _value_ to a property on this map instance called _propName_.  This will define
+	 * the property if it hasn't already been predefined.
+	 *
+	 *   @param {String} propName The property to set.
+	 *   @param {*} value The value to assign to `propName`.
+	 *   @return {can-define/map/map} This map instance, for chaining.
+	 */
+	set: function(prop, value){
+		if(typeof prop === "object") {
+			return setProps.call(this, prop, value);
+		}
+		var defined = defineHelpers.defineExpando(this, prop, value);
+		if(!defined) {
+			this[prop] = value;
+		}
+		return this;
+	},
+	/**
+	 * @function can-define/map/map.prototype.serialize serialize
+	 * @parent can-define/map/map.prototype
+	 *
+	 * @description Get a serialized representation of the map instance and its children.
+	 *
+	 * @signature `map.serialize()`
+	 *
+	 * Get the serialized Object form of the map.  Serialized
+	 * data is typically used to send back to a server.  Use [can-define.types.serialize]
+	 * to customize a property's serialized value or if the property should be added to
+	 * the result or not.
+	 *
+	 * `undefined` serialized values are not added to the result.
+	 *
+	 * ```js
+	 * var MyMap = DefineMap.extend({
+	 *   date: {
+	 *     type: "date",
+	 *     serialize: function(date){
+	 *       return date.getTime()
+	 *     }
+	 *   }
+	 * });
+	 *
+	 * var myMap = new MyMap({date: new Date(), count: 5});
+	 * myMap.serialize() //-> {date: 1469566698504, count: 5}
+	 * ```
+	 *
+	 *   @return {Object} A JavaScript Object that can be serialized with `JSON.stringify` or other methods.
+	 *
+	 */
+	serialize: function () {
+		return defineHelpers.serialize(this, 'serialize', {});
+	},
 
-    forEach: function(cb, thisarg, observe){
-        if(observe !== false) {
-            Observation.add(this, '__keys');
-        }
-        var res;
-        var constructorDefinitions = this._define.definitions;
-        if(constructorDefinitions) {
-            res = eachDefinition(this, cb, thisarg, constructorDefinitions, observe);
-        }
-        if(res === false) {
-            return this;
-        }
-        if(this._instanceDefinitions) {
-            eachDefinition(this, cb, thisarg, this._instanceDefinitions, observe);
-        }
+	forEach: function(cb, thisarg, observe){
+		if(observe !== false) {
+			Observation.add(this, '__keys');
+		}
+		var res;
+		var constructorDefinitions = this._define.definitions;
+		if(constructorDefinitions) {
+			res = eachDefinition(this, cb, thisarg, constructorDefinitions, observe);
+		}
+		if(res === false) {
+			return this;
+		}
+		if(this._instanceDefinitions) {
+			eachDefinition(this, cb, thisarg, this._instanceDefinitions, observe);
+		}
 
-        return this;
-    },
-    "*": {
-        type: define.types.observable
-    }
+		return this;
+	},
+	"*": {
+		type: define.types.observable
+	}
 });
 
 // Add necessary event methods to this object.
 for(var prop in define.eventsProto) {
-    Object.defineProperty(DefineMap.prototype, prop, {
-        enumerable:false,
-        value: define.eventsProto[prop]
-    });
+	Object.defineProperty(DefineMap.prototype, prop, {
+		enumerable:false,
+		value: define.eventsProto[prop]
+	});
 }
 types.DefineMap = DefineMap;
 types.DefaultMap = DefineMap;
 
 DefineMap.prototype.toObject = function(){
-    console.warn("Use DefineMap::get instead of DefineMap::toObject");
-    return this.get();
+	console.warn("Use DefineMap::get instead of DefineMap::toObject");
+	return this.get();
 };
 DefineMap.prototype.each = DefineMap.prototype.forEach;
 

--- a/map/map.js
+++ b/map/map.js
@@ -277,6 +277,7 @@ var DefineMap = Construct.extend("DefineMap",{
 
 // Add necessary event methods to this object.
 for(var prop in define.eventsProto) {
+	DefineMap[prop] = define.eventsProto[prop];
     Object.defineProperty(DefineMap.prototype, prop, {
         enumerable:false,
         value: define.eventsProto[prop],

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "can-cid": "^1.0.0",
     "can-compute": "^3.0.0",
     "can-construct": "^3.0.6",
-    "can-event": "^3.0.1",
+    "can-event": "^3.3.0",
     "can-namespace": "^1.0.0",
     "can-observation": "^3.0.1",
     "can-types": "^1.0.1",


### PR DESCRIPTION
Covers #92 and other issues found when trying to convert between can.Map and DefineMap, which aren't currently playing nice with each other in certain cases.

These operations will help bridge that gap, and prevent some issues, but there are limitations to the current approach:
* I haven't touched on anything specific to DefineList yet, and I'm sure it has its own problems, but currently I'm having more, and more frequent, issues going between can.Map and DefineMap.

But here's what's been done so far:
* For cases where DefineMaps are being sent to other objects for assignment, the `constructor` property, the `"*"` defintition, and the prototype functions are made non-enumerable.  This prevents the prototype functions on target objects being overwritten, causing incorrect object behavior, and prevents a crash when trying to set the `constructor` property of can.Maps.
* For the reverse case, assigning other objects to DefineMaps, the special keys that matter to operating a DefineMap (_data, _bindEvents, constructor, and _cid) are scrubbed from input sources before assigning those inputs to a new or existing DefineMap.
* The `_bindings` special property was pushed into `__bindEvents` in can-event 3.3 so managing it is now not an issue.
* `define()` now defines its special properties (`__bindEvents`, `_cid`, and `constructor`) as not writable, to avoid other observable-like objects overwriting these properties incorrectly.
* The `.set(Object)` is accounted for, `new DefineMap(Object)` as well, and enough has been done to make `assign(DefineMap, Object)` work as intended, even if the second arg has special props.  However, testing could still be more comprehensive with another pair of eyes reviewing it.
