### PR TITLE
Ensure can-cid isn't double loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
   },
   "homepage": "https://github.com/canjs/can-define",
   "dependencies": {
-    "can-cid": "^0.1.0",
+    "can-cid": "^1.0.0",
     "can-compute": "^3.0.0",
     "can-construct": "^3.0.0",
     "can-event": "^3.0.1",
     "can-namespace": "^1.0.0",
     "can-observation": "^3.0.1",
-    "can-types": "^0.1.0",
+    "can-types": "^1.0.0",
     "can-util": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
can-namepspaces throws an error if multiple can-cid versions are loaded. This PR fixes the version mismatch

See #113 