### PR TITLE
Mix events into Map and List Constructors

### DIFF
--- a/list/list-test.js
+++ b/list/list-test.js
@@ -14,8 +14,7 @@ QUnit.module("can-define/list/list");
 
 QUnit.test("List is an event emitter", function (assert) {
 	var List = DefineList.extend({});
-	assert.ok(DefineList.on, 'Event methods have been copied to DefineList.');
-	assert.ok(List.on, 'Event methods have been copied to the List.');
+	assert.ok(List.on, 'List has event methods.');
 });
 
 QUnit.test("creating an instance", function(){

--- a/list/list-test.js
+++ b/list/list-test.js
@@ -12,6 +12,12 @@ var stache = require("can-stache");
 
 QUnit.module("can-define/list/list");
 
+QUnit.test("List is an event emitter", function (assert) {
+	var List = DefineList.extend({});
+	assert.ok(DefineList.on, 'Event methods have been copied to DefineList.');
+	assert.ok(List.on, 'Event methods have been copied to the List.');
+});
+
 QUnit.test("creating an instance", function(){
     var list = new DefineList(["a","b","c"]);
 

--- a/list/list-test.js
+++ b/list/list-test.js
@@ -13,7 +13,9 @@ var stache = require("can-stache");
 QUnit.module("can-define/list/list");
 
 QUnit.test("List is an event emitter", function (assert) {
-	var List = DefineList.extend({});
+	var Base = DefineList.extend({});
+	assert.ok(Base.on, 'Base has event methods.');
+	var List = Base.extend({});
 	assert.ok(List.on, 'List has event methods.');
 });
 

--- a/list/list.js
+++ b/list/list.js
@@ -1049,6 +1049,7 @@ assign(DefineList.prototype, {
 
 // Add necessary event methods to this object.
 for (var prop in define.eventsProto) {
+	DefineList[prop] = define.eventsProto[prop];
 	Object.defineProperty(DefineList.prototype, prop, {
 		enumerable: false,
 		value: define.eventsProto[prop],

--- a/list/list.js
+++ b/list/list.js
@@ -1049,11 +1049,7 @@ assign(DefineList.prototype, {
 
 // Add necessary event methods to this object.
 for (var prop in define.eventsProto) {
-	Object.defineProperty(DefineList, prop, {
-		enumerable: true,
-		value: define.eventsProto[prop],
-		writable: true
-	});
+	DefineList[prop] = define.eventsProto[prop];
 	Object.defineProperty(DefineList.prototype, prop, {
 		enumerable: false,
 		value: define.eventsProto[prop],

--- a/list/list.js
+++ b/list/list.js
@@ -1049,7 +1049,11 @@ assign(DefineList.prototype, {
 
 // Add necessary event methods to this object.
 for (var prop in define.eventsProto) {
-	DefineList[prop] = define.eventsProto[prop];
+	Object.defineProperty(DefineList, prop, {
+		enumerable: true,
+		value: define.eventsProto[prop],
+		writable: true
+	});
 	Object.defineProperty(DefineList.prototype, prop, {
 		enumerable: false,
 		value: define.eventsProto[prop],

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -19,8 +19,7 @@ QUnit.module("can-define/map/map");
 
 QUnit.test("Map is an event emitter", function (assert) {
 	var Map = DefineMap.extend({});
-	assert.ok(DefineMap.on, 'Event methods have been copied to DefineMap.');
-	assert.ok(Map.on, 'Event methods have been copied to the Map.');
+	assert.ok(Map.on, 'Map has event methods.');
 });
 
 QUnit.test("creating an instance", function(){

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -18,7 +18,9 @@ var sealWorks = (function() {
 QUnit.module("can-define/map/map");
 
 QUnit.test("Map is an event emitter", function (assert) {
-	var Map = DefineMap.extend({});
+	var Base = DefineMap.extend({});
+	assert.ok(Base.on, 'Base has event methods.');
+	var Map = Base.extend({});
 	assert.ok(Map.on, 'Map has event methods.');
 });
 

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -17,6 +17,12 @@ var sealWorks = (function() {
 
 QUnit.module("can-define/map/map");
 
+QUnit.test("Map is an event emitter", function (assert) {
+	var List = DefineMap.extend({});
+	assert.ok(DefineMap.on, 'Event methods have been copied to DefineMap.');
+	assert.ok(List.on, 'Event methods have been copied to the List.');
+});
+
 QUnit.test("creating an instance", function(){
     var map = new DefineMap({prop: "foo"});
     map.on("prop", function(ev, newVal, oldVal){

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -18,9 +18,9 @@ var sealWorks = (function() {
 QUnit.module("can-define/map/map");
 
 QUnit.test("Map is an event emitter", function (assert) {
-	var List = DefineMap.extend({});
+	var Map = DefineMap.extend({});
 	assert.ok(DefineMap.on, 'Event methods have been copied to DefineMap.');
-	assert.ok(List.on, 'Event methods have been copied to the List.');
+	assert.ok(Map.on, 'Event methods have been copied to the Map.');
 });
 
 QUnit.test("creating an instance", function(){

--- a/map/map.js
+++ b/map/map.js
@@ -260,11 +260,7 @@ var DefineMap = Construct.extend("DefineMap",{
 
 // Add necessary event methods to this object.
 for(var prop in define.eventsProto) {
-    Object.defineProperty(DefineMap, prop, {
-        enumerable:true,
-        value: define.eventsProto[prop],
-        writable: true
-    });
+    DefineMap[prop] = define.eventsProto[prop];
     Object.defineProperty(DefineMap.prototype, prop, {
         enumerable:false,
         value: define.eventsProto[prop],

--- a/map/map.js
+++ b/map/map.js
@@ -260,10 +260,15 @@ var DefineMap = Construct.extend("DefineMap",{
 
 // Add necessary event methods to this object.
 for(var prop in define.eventsProto) {
-    DefineMap[prop] = define.eventsProto[prop];
+    Object.defineProperty(DefineMap, prop, {
+        enumerable:true,
+        value: define.eventsProto[prop],
+		writable: true
+    });
     Object.defineProperty(DefineMap.prototype, prop, {
         enumerable:false,
-        value: define.eventsProto[prop]
+        value: define.eventsProto[prop],
+		writable: true
     });
 }
 types.DefineMap = DefineMap;

--- a/map/map.js
+++ b/map/map.js
@@ -260,6 +260,7 @@ var DefineMap = Construct.extend("DefineMap",{
 
 // Add necessary event methods to this object.
 for(var prop in define.eventsProto) {
+    DefineMap[prop] = define.eventsProto[prop];
     Object.defineProperty(DefineMap.prototype, prop, {
         enumerable:false,
         value: define.eventsProto[prop]

--- a/map/map.js
+++ b/map/map.js
@@ -268,7 +268,7 @@ for(var prop in define.eventsProto) {
     Object.defineProperty(DefineMap.prototype, prop, {
         enumerable:false,
         value: define.eventsProto[prop],
-		writable: true
+        writable: true
     });
 }
 types.DefineMap = DefineMap;

--- a/map/map.js
+++ b/map/map.js
@@ -263,7 +263,7 @@ for(var prop in define.eventsProto) {
     Object.defineProperty(DefineMap, prop, {
         enumerable:true,
         value: define.eventsProto[prop],
-		writable: true
+        writable: true
     });
     Object.defineProperty(DefineMap.prototype, prop, {
         enumerable:false,


### PR DESCRIPTION
Adds can-event methods onto the Map and List Constructors.

```js
var List = DefineList.extend({});
assert.ok(List.on, 'List has event methods.');
```