### PR TITLE
Make JsHint ignore the ./dist directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "can-define.js",
   "scripts": {
     "build": "node build.js",
-    "jshint": "jshint --config .jshintrc --exclude ./node_modules .",
+    "jshint": "jshint --config .jshintrc --exclude ./node_modules,./dist .",
     "preversion": "npm test && npm run build",
     "version": "git commit -am \"Update dist for release\" && git checkout -b release && git add -f dist/",
     "postversion": "git push --tags && git checkout master && git branch -D release && git push",


### PR DESCRIPTION
This will prevent Travis from failing during releases because jshint hint has been linting the `./dist` folder.