### PR TITLE
Call `set` behavior in `value` or `Value`

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -461,12 +461,20 @@ make = {
 					if (typeof value === "function") {
 						value = value.call(this);
 					}
-					return typeConvert(value);
+					value = typeConvert(value);
 				}
-				var Value = definition.Value;
-				if (Value) {
-					return typeConvert(new Value());
+				else {
+					var Value = definition.Value;
+					if (Value) {
+						value = typeConvert(new Value());
+					}
 				}
+				if(definition.set) {
+					if(definition.set.length > 0) {
+						value = definition.set.call(this, value);
+					}
+				}
+				return value;
 			};
 		},
 		data: function(prop) {

--- a/define-test.js
+++ b/define-test.js
@@ -502,7 +502,7 @@ test("Value generator can read other properties", function() {
 });
 
 test('default behaviors with "*" work for attributes', function() {
-	expect(5);
+	expect(6);
 	var DefaultMap = define.Constructor({
 		'*': {
 			type: 'number',
@@ -1435,4 +1435,22 @@ QUnit.test("shorthand getter setter (#56)", function() {
 	equal(p.fullName, "Mohamed Cherif", "fullName initialized right");
 
 	p.fullName = "Justin Meyer";
+});
+
+
+QUnit.test("set and value work together (#87)", function(){
+
+	var Type = define.Constructor({
+		prop: {
+			value: 2,
+			set: function(num){
+				return num * num;
+			}
+		}
+	});
+
+	var instance = new Type();
+
+	QUnit.equal(instance.prop, 4, "used setter");
+
 });


### PR DESCRIPTION
fixes #87.

I'm not in love with this solution.  This makes `defaultValue` know about `set`.  It doesn't work with `async` setters, though it does check to make sure that side-effect only setters aren't run.  

A better solution would somehow be able to run the compiled `setter`, but without having it trigger events or actually do the setting.  

We need sort of a "figure out set value" -> "actually set value" flow.  