### PR TITLE
Make async sets work with `value`

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -170,10 +170,14 @@ define.property = function(objPrototype, prop, definition, dataInitializers, com
 		typeConvert = make.set.type(prop, type, typeConvert);
 	}
 
+	// make a setter that's going to fire of events
+	var eventsSetter = make.set.events(prop, reader, setter, make.eventType[dataProperty](prop));
+
 	// Determine a function that will provide the initial property value.
 	if ((definition.value !== undefined || definition.Value !== undefined)) {
-		getInitialValue = make.get.defaultValue(prop, definition, typeConvert);
+		getInitialValue = make.get.defaultValue(prop, definition, typeConvert, eventsSetter);
 	}
+	
 	// If property has a getter, create the compute that stores its data.
 	if (definition.get) {
 		computedInitializers[prop] = make.compute(prop, definition.get, getInitialValue);
@@ -190,19 +194,18 @@ define.property = function(objPrototype, prop, definition, dataInitializers, com
 	// If there's a `get` and `set`, make the setter get the `lastSetValue` on the
 	// `get`'s compute.
 	if (definition.get && definition.set) {
+		// the compute will set off events, so we can use the basic setter
 		setter = make.set.setter(prop, definition.set, make.read.lastSet(prop), setter, true);
 	}
 	// If there's a `set` and no `get`,
 	else if (definition.set) {
-		// make a set that produces events.
-		setter = make.set.events(prop, reader, setter, make.eventType[dataProperty](prop));
-		// Add `set` functionality to the setter.
-		setter = make.set.setter(prop, definition.set, reader, setter, false);
+		// Add `set` functionality to the eventSetter.
+		setter = make.set.setter(prop, definition.set, reader, eventsSetter, false);
 	}
 	// If there's niether `set` or `get`,
 	else if (!definition.get) {
 		// make a set that produces events.
-		setter = make.set.events(prop, reader, setter, make.eventType[dataProperty](prop));
+		setter = eventsSetter;
 	}
 
 	// Add type behavior to the setter.
@@ -454,7 +457,7 @@ make = {
 	// Helpers that read the data in an observable way.
 	get: {
 		// uses the default value
-		defaultValue: function(prop, definition, typeConvert) {
+		defaultValue: function(prop, definition, typeConvert, callSetter) {
 			return function() {
 				var value = definition.value;
 				if (value !== undefined) {
@@ -470,9 +473,27 @@ make = {
 					}
 				}
 				if(definition.set) {
-					if(definition.set.length > 0) {
-						value = definition.set.call(this, value);
-					}
+					// TODO: there's almost certainly a faster way of making this happen
+					// But this is maintainable.
+
+					var VALUE;
+					var sync = true;
+
+					var setter = make.set.setter(prop, definition.set, function(){}, function(value){
+						if(sync) {
+							VALUE = value;
+						} else {
+							callSetter.call(this, value);
+						}
+					}, definition.get);
+
+					setter.call(this,value);
+					sync= false;
+
+					// VALUE will be undefined if the callback is never called.
+					return VALUE;
+
+
 				}
 				return value;
 			};

--- a/define-test.js
+++ b/define-test.js
@@ -1454,3 +1454,38 @@ QUnit.test("set and value work together (#87)", function(){
 	QUnit.equal(instance.prop, 4, "used setter");
 
 });
+
+QUnit.test("async setter is provided", 5, function(){
+	var RESOLVE;
+
+	var Type = define.Constructor({
+		prop: {
+			value: 2,
+			set: function(num, resolve){
+				resolve( num * num );
+			}
+		},
+		prop2: {
+			value: 3,
+			set: function(num, resolve){
+				RESOLVE = resolve;
+			}
+		}
+	});
+
+	var instance = new Type();
+
+	QUnit.equal(instance.prop, 4, "used async setter");
+
+
+	QUnit.equal(instance.prop2, undefined, "used async setter");
+
+	instance.on("prop2", function(ev, newVal, oldVal){
+		QUnit.equal(newVal, 9, "updated");
+		QUnit.equal(oldVal, undefined, "updated");
+	});
+	RESOLVE(9);
+
+	QUnit.equal(instance.prop2, 9, "used async setter updates after");
+
+});


### PR DESCRIPTION
fixes #132

This manages to use `make.set.setter(` so we don't have to duplicate the behavior of how `set` is called while still not firing an event in the case that `set` returns a value or calls `resolve` immediately.

It does this in a less-than-ideal way performance-wise as it calls `make.set.setter` everytime to generate a function.  This is so we can know the state if the `setter` callback was called immediately.

In the end, this works and is relatively maintainable, while it suffers a bit from a performance drag.