### PR TITLE
Default value setter infinite loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js: node
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+addons:
+  firefox: "latest"

--- a/can-define.js
+++ b/can-define.js
@@ -626,6 +626,10 @@ replaceWith = function(obj, prop, cb, writable) {
 	Object.defineProperty(obj, prop, {
 		configurable: true,
 		get: function() {
+			Object.defineProperty(this, prop, {
+				value: undefined,
+				writable: true
+			});
 			var value = cb.call(this, obj, prop);
 			Object.defineProperty(this, prop, {
 				value: value,

--- a/define-test.js
+++ b/define-test.js
@@ -1495,7 +1495,7 @@ QUnit.test('setter with default value causes an infinite loop (#142)', function(
 		val: {
 			value: 'hello',
 			set(val){ // jshint ignore:line
-				console.log(this.val);
+				if(this.val) {}
 				return val;
 			}
 		}

--- a/define-test.js
+++ b/define-test.js
@@ -1494,7 +1494,7 @@ QUnit.test('setter with default value causes an infinite loop (#142)', function(
 	var A = define.Constructor({
 		val: {
 			value: 'hello',
-			set(val){ // jshint ignore:line
+			set: function(val){
 				if(this.val) {}
 				return val;
 			}

--- a/define-test.js
+++ b/define-test.js
@@ -1489,3 +1489,18 @@ QUnit.test("async setter is provided", 5, function(){
 	QUnit.equal(instance.prop2, 9, "used async setter updates after");
 
 });
+
+QUnit.test('setter with default value causes an infinite loop (#142)', function(){
+	var A = define.Constructor({
+		val: {
+			value: 'hello',
+			set(val){
+				console.log(this.val);
+				return val;
+			}
+		}
+	});
+
+	var a = new A();
+	QUnit.equal(a.val, 'hello', 'creating an instance should not cause an inifinte loop');
+});

--- a/define-test.js
+++ b/define-test.js
@@ -1494,7 +1494,7 @@ QUnit.test('setter with default value causes an infinite loop (#142)', function(
 	var A = define.Constructor({
 		val: {
 			value: 'hello',
-			set(val){
+			set(val){ // jshint ignore:line
 				console.log(this.val);
 				return val;
 			}


### PR DESCRIPTION
This fixes the issue with calling `this.val` in a setter where `value` or `Value` of `val` is defined causing infinite recursion.

Closes #142 