### PR TITLE
DefineList::replace use can-util/diff

### DIFF
--- a/list/list-test.js
+++ b/list/list-test.js
@@ -821,3 +821,31 @@ QUnit.test("Array shorthand uses #", function() {
 	map.numbers.set("prop", "4");
 	QUnit.ok(map.numbers.prop === "4", "type left alone");
 });
+
+test("replace-with-self lists are diffed properly", function() {
+	var a = new DefineMap({ name: "A" });
+	var b = new DefineMap({ name: "B" });
+	var c = new DefineMap({ name: "C" });
+	var d = new DefineMap({ name: "D" });
+	expect(4);
+
+	var list1 = new DefineList([ a, b ]);
+	list1.on("add", function(ev, newVals, where) {
+		throw new Error("list1 should not add.");
+	});
+	list1.on("remove", function(ev, oldVals, where) {
+		throw new Error("list1 should not remove.");
+	});
+	list1.replace([ a, b ]);
+
+	var list2 = new DefineList([ a, b, c ]);
+	list2.on("add", function(ev, newVals, where) {
+		equal(newVals.length, 1, "list2 added length");
+		equal(where, 2, "list2 added location");
+	});
+	list2.on("remove", function(ev, oldVals, where) {
+		equal(oldVals.length, 1, "list2 removed length");
+		equal(where, 2, "list2 removed location");
+	});
+	list2.replace([ a, b, d ]);
+});

--- a/list/list-test.js
+++ b/list/list-test.js
@@ -12,25 +12,25 @@ var stache = require("can-stache");
 
 QUnit.module("can-define/list/list");
 
-QUnit.test("List is an event emitter", function (assert) {
+QUnit.test("List is an event emitter", function(assert) {
 	var Base = DefineList.extend({});
 	assert.ok(Base.on, 'Base has event methods.');
 	var List = Base.extend({});
 	assert.ok(List.on, 'List has event methods.');
 });
 
-QUnit.test("creating an instance", function(){
-    var list = new DefineList(["a","b","c"]);
+QUnit.test("creating an instance", function() {
+	var list = new DefineList([ "a", "b", "c" ]);
 
-    list.on("add", function(ev, newVals, index){
-        QUnit.deepEqual(newVals, ["d"]);
-        QUnit.equal(index, 3);
-    });
+	list.on("add", function(ev, newVals, index) {
+		QUnit.deepEqual(newVals, [ "d" ]);
+		QUnit.equal(index, 3);
+	});
 
-    list.push("d");
+	list.push("d");
 });
 
-test('list attr changes length', function () {
+test('list attr changes length', function() {
 	var l = new DefineList([
 		0,
 		1,
@@ -40,13 +40,13 @@ test('list attr changes length', function () {
 	equal(l.length, 4);
 });
 test('remove on pop', function() {
-	var l = new DefineList([0, 1, 2]);
-    l.pop();
+	var l = new DefineList([ 0, 1, 2 ]);
+	l.pop();
 
 	equal(l.length, 2);
-	deepEqual(l.get(), [0, 1]);
+	deepEqual(l.get(), [ 0, 1 ]);
 });
-test('list splice', function () {
+test('list splice', function() {
 	var l = new DefineList([
 		0,
 		1,
@@ -54,21 +54,21 @@ test('list splice', function () {
 		3
 	]);
 
-    l.on('add', function(ev, newVals, index){
-        deepEqual(newVals, [
-            'a',
-            'b'
-        ], 'got the right newVals');
-        equal(index, 1, 'adding items');
-    });
+	l.on('add', function(ev, newVals, index) {
+		deepEqual(newVals, [
+			'a',
+			'b'
+		], 'got the right newVals');
+		equal(index, 1, 'adding items');
+	});
 
-    l.on('remove', function(ev, oldVals, index){
-        deepEqual(oldVals, [
-            1,
-            2
-        ], 'got the right oldVals');
-        equal(index, 1, 'no new Vals');
-    });
+	l.on('remove', function(ev, oldVals, index) {
+		deepEqual(oldVals, [
+			1,
+			2
+		], 'got the right oldVals');
+		equal(index, 1, 'no new Vals');
+	});
 
 	l.splice(1, 2, 'a', 'b');
 	deepEqual(l.get(), [
@@ -80,18 +80,18 @@ test('list splice', function () {
 });
 
 
-test('Array accessor methods', 11, function () {
+test('Array accessor methods', 11, function() {
 	var l = new DefineList([
-		'a',
-		'b',
-		'c'
-	]),
+			'a',
+			'b',
+			'c'
+		]),
 		sliced = l.slice(2),
 		joined = l.join(' | '),
 		concatenated = l.concat([
 			2,
 			1
-		], new DefineList([0]));
+		], new DefineList([ 0 ]));
 	ok(sliced instanceof DefineList, 'Slice is an Observable list');
 	equal(sliced.length, 1, 'Sliced off two elements');
 	equal(sliced[0], 'c', 'Single element as expected');
@@ -105,7 +105,7 @@ test('Array accessor methods', 11, function () {
 		1,
 		0
 	], 'DefineList concatenated properly');
-	l.forEach(function (letter, index) {
+	l.forEach(function(letter, index) {
 		ok(true, 'Iteration');
 		if (index === 0) {
 			equal(letter, 'a', 'First letter right');
@@ -150,15 +150,15 @@ test('Lists with maps concatenate properly', function() {
 		hero
 	]);
 
-	people = people.concat([me, animal, specialPeople], specialPeople, [1, 2], 3);
+	people = people.concat([ me, animal, specialPeople ], specialPeople, [ 1, 2 ], 3);
 
 	ok(people.length === 8, "List length is right");
 	ok(people[0] === me, "Map in list === vars created before concat");
 	ok(people[1] instanceof Person, "Animal got serialized to Person");
 });
 
-test('splice removes items in IE (#562)', function () {
-	var l = new DefineList(['a']);
+test('splice removes items in IE (#562)', function() {
+	var l = new DefineList([ 'a' ]);
 	l.splice(0, 1);
 	ok(!l.get(0), 'all props are removed');
 });
@@ -166,21 +166,27 @@ test('splice removes items in IE (#562)', function () {
 
 test('reverse triggers add/remove events (#851)', function() {
 	expect(5);
-	var l = new DefineList([1,2,3]);
+	var l = new DefineList([ 1, 2, 3 ]);
 
-	l.on('add', function() { ok(true, 'add called'); });
-	l.on('remove', function() { ok(true, 'remove called'); });
-	l.on('length', function() { ok(true, 'length should be called'); });
+	l.on('add', function() {
+		ok(true, 'add called');
+	});
+	l.on('remove', function() {
+		ok(true, 'remove called');
+	});
+	l.on('length', function() {
+		ok(true, 'length should be called');
+	});
 
 	l.reverse();
 
-    deepEqual(l.get(), [3,2,1], "reversed");
+	deepEqual(l.get(), [ 3, 2, 1 ], "reversed");
 });
 
-test('filter', function(){
-	var l = new DefineList([{id: 1, name: "John"}, {id: 2, name: "Mary"}]);
+test('filter', function() {
+	var l = new DefineList([ { id: 1, name: "John" }, { id: 2, name: "Mary" } ]);
 
-	var filtered = l.filter(function(item){
+	var filtered = l.filter(function(item) {
 		return item.name === "Mary";
 	});
 
@@ -191,7 +197,7 @@ test('filter', function(){
 });
 
 test('No Add Events if DefineList Splice adds the same items that it is removing. (#1277, #1399)', function() {
-	var list = new DefineList(["a","b"]);
+	var list = new DefineList([ "a", "b" ]);
 
 	list.bind('add', function() {
 		ok(false, 'Add callback should not be called.');
@@ -201,16 +207,16 @@ test('No Add Events if DefineList Splice adds the same items that it is removing
 		ok(false, 'Remove callback should not be called.');
 	});
 
-  var result = list.splice(0, 2, "a", "b");
+	var result = list.splice(0, 2, "a", "b");
 
-  deepEqual(result, ["a", "b"]);
+	deepEqual(result, [ "a", "b" ]);
 });
 
 test("add event always returns an array as the value (#998)", function() {
 	var list = new DefineList([]),
 		msg;
 	list.bind("add", function(ev, newElements, index) {
-		deepEqual(newElements, [4], msg);
+		deepEqual(newElements, [ 4 ], msg);
 	});
 	msg = "works on push";
 	list.push(4);
@@ -219,14 +225,14 @@ test("add event always returns an array as the value (#998)", function() {
 	list.set(0, 4);
 	list.pop();
 	msg = "works on replace()";
-	list.replace([4]);
+	list.replace([ 4 ]);
 });
 
 test("Setting with .set() out of bounds of length triggers add event with leading undefineds", function() {
-	var list = new DefineList([1]);
+	var list = new DefineList([ 1 ]);
 	list.bind("add", function(ev, newElements, index) {
-		deepEqual(newElements, [undefined, undefined, 4],
-				  "Leading undefineds are included");
+		deepEqual(newElements, [ undefined, undefined, 4 ],
+			"Leading undefineds are included");
 		equal(index, 1, "Index takes into account the leading undefineds from a .set()");
 	});
 	list.set(3, 4);
@@ -254,20 +260,20 @@ test('setting an index out of bounds does not create an array', function() {
 });
 
 test('splice with similar but less items works (#1606)', function() {
-	var list = new DefineList([ 'aa', 'bb', 'cc']);
+	var list = new DefineList([ 'aa', 'bb', 'cc' ]);
 
 	list.splice(0, list.length, 'aa', 'cc', 'dd');
-	deepEqual(list.get(), ['aa', 'cc', 'dd']);
+	deepEqual(list.get(), [ 'aa', 'cc', 'dd' ]);
 
 	list.splice(0, list.length, 'aa', 'cc');
-	deepEqual(list.get(), ['aa', 'cc']);
+	deepEqual(list.get(), [ 'aa', 'cc' ]);
 });
 
 test('filter returns same list type (#1744)', function() {
 	var ParentList = DefineList.extend();
 	var ChildList = ParentList.extend();
 
-	var children = new ChildList([1,2,3]);
+	var children = new ChildList([ 1, 2, 3 ]);
 
 	ok(children.filter(function() {}) instanceof ChildList);
 });
@@ -276,29 +282,29 @@ test('reverse returns the same list instance (#1744)', function() {
 	var ParentList = DefineList.extend();
 	var ChildList = ParentList.extend();
 
-	var children = new ChildList([1,2,3]);
+	var children = new ChildList([ 1, 2, 3 ]);
 	ok(children.reverse() === children);
 });
 
 
-test("slice and join are observable by a compute (#1884)", function(){
+test("slice and join are observable by a compute (#1884)", function() {
 	expect(2);
 
-	var list = new DefineList([1,2,3]);
+	var list = new DefineList([ 1, 2, 3 ]);
 
-	var sliced = new Observation(function(){
-		return list.slice(0,1);
+	var sliced = new Observation(function() {
+		return list.slice(0, 1);
 	}, null, {
-		updater: function(newVal){
-			deepEqual(newVal.get(), [2], "got a new DefineList");
+		updater: function(newVal) {
+			deepEqual(newVal.get(), [ 2 ], "got a new DefineList");
 		}
 	});
 	sliced.start();
 
-	var joined = new Observation(function(){
+	var joined = new Observation(function() {
 		return list.join(",");
 	}, null, {
-		updater: function(newVal){
+		updater: function(newVal) {
 			equal(newVal, "2,3", "joined is observable");
 		}
 	});
@@ -310,91 +316,91 @@ test("slice and join are observable by a compute (#1884)", function(){
 
 });
 
-test('list.replace', function(){
-    var firstArray = [
-        {id: 1, name: "Marshall"},
-        {id: 2, name: "Austin"},
-        {id: 3, name: "Hyrum"}
-    ];
-    var myList = new DefineList(firstArray);
-    var newArray = [
-        {id: 4, name: "Aubree"},
-        {id: 5, name: "Leah"},
-        {id: 6, name: 'Lily'}
-    ];
-    myList.replace(newArray);
-    equal(myList.length, 3);
-    equal(myList[0].name, "Aubree");
-    equal(myList[1].name, "Leah");
-    equal(myList[2].name, "Lily", "Can replace a List with an Array.");
+test('list.replace', function() {
+	var firstArray = [
+		{ id: 1, name: "Marshall" },
+		{ id: 2, name: "Austin" },
+		{ id: 3, name: "Hyrum" }
+	];
+	var myList = new DefineList(firstArray);
+	var newArray = [
+		{ id: 4, name: "Aubree" },
+		{ id: 5, name: "Leah" },
+		{ id: 6, name: 'Lily' }
+	];
+	myList.replace(newArray);
+	equal(myList.length, 3);
+	equal(myList[0].name, "Aubree");
+	equal(myList[1].name, "Leah");
+	equal(myList[2].name, "Lily", "Can replace a List with an Array.");
 
-    myList.replace(firstArray);
-    equal(myList.length, 3);
-    equal(myList[0].name, "Marshall");
-    equal(myList[1].name, "Austin");
-    equal(myList[2].name, "Hyrum", "Can replace a List with another List.");
+	myList.replace(firstArray);
+	equal(myList.length, 3);
+	equal(myList[0].name, "Marshall");
+	equal(myList[1].name, "Austin");
+	equal(myList[2].name, "Hyrum", "Can replace a List with another List.");
 });
 
-test('list.map', function(){
+test('list.map', function() {
 	var myArray = [
-	    {id: 1, name: "Marshall"},
-	    {id: 2, name: "Austin"},
-	    {id: 3, name: "Hyrum"}
-    ];
-    var myList = new DefineList(myArray);
-    var newList = myList.map(function(person) {
-        person.lastName = "Thompson";
-        return person;
-    });
+		{ id: 1, name: "Marshall" },
+		{ id: 2, name: "Austin" },
+		{ id: 3, name: "Hyrum" }
+	];
+	var myList = new DefineList(myArray);
+	var newList = myList.map(function(person) {
+		person.lastName = "Thompson";
+		return person;
+	});
 
-    equal(newList.length, 3);
-    equal(newList[0].name, "Marshall");
-    equal(newList[0].lastName, "Thompson");
-    equal(newList[1].name, "Austin");
-    equal(newList[1].lastName, "Thompson");
-    equal(newList[2].name, "Hyrum");
-    equal(newList[2].lastName, "Thompson");
+	equal(newList.length, 3);
+	equal(newList[0].name, "Marshall");
+	equal(newList[0].lastName, "Thompson");
+	equal(newList[1].name, "Austin");
+	equal(newList[1].lastName, "Thompson");
+	equal(newList[2].name, "Hyrum");
+	equal(newList[2].lastName, "Thompson");
 
-    var ExtendedList = DefineList.extend({
-		testMe: function(){
+	var ExtendedList = DefineList.extend({
+		testMe: function() {
 			return "It Worked!";
 		}
 	});
 	var myExtendedList = new ExtendedList(myArray);
 	var newExtendedList = myExtendedList.map(function(person) {
-    person.lastName = "Thompson";
-	    return person;
+		person.lastName = "Thompson";
+		return person;
 	});
 	QUnit.equal("It Worked!", newExtendedList.testMe(), 'Returns the same type of list.');
 });
 
 
-test('list.sort a simple list', function(){
-    var myList = new DefineList([
-	    "Marshall",
-	    "Austin",
-	    "Hyrum"
-    ]);
+test('list.sort a simple list', function() {
+	var myList = new DefineList([
+		"Marshall",
+		"Austin",
+		"Hyrum"
+	]);
 
 	myList.sort();
 
-    equal(myList.length, 3);
-    equal(myList[0], "Austin");
+	equal(myList.length, 3);
+	equal(myList[0], "Austin");
 	equal(myList[1], "Hyrum");
 	equal(myList[2], "Marshall", "Basic list was properly sorted.");
 });
 
-test('list.sort a list of objects', function(){
+test('list.sort a list of objects', function() {
 	var objList = new DefineList([
-		{id: 1, name: "Marshall"},
-		{id: 2, name: "Austin"},
-		{id: 3, name: "Hyrum"}
+		{ id: 1, name: "Marshall" },
+		{ id: 2, name: "Austin" },
+		{ id: 3, name: "Hyrum" }
 	]);
 
-	objList.sort(function(a, b){
+	objList.sort(function(a, b) {
 		if (a.name < b.name) {
 			return -1;
-		} else if (a.name > b.name){
+		} else if (a.name > b.name) {
 			return 1;
 		} else {
 			return 0;
@@ -407,22 +413,22 @@ test('list.sort a list of objects', function(){
 	equal(objList[2].name, "Marshall", "List of objects was properly sorted.");
 });
 
-test('list.sort a list of DefineMaps', function(){
+test('list.sort a list of DefineMaps', function() {
 	var Account = DefineMap.extend({
 		name: "string",
 		amount: "number",
 		slug: {
 			serialize: true,
-			get: function(){
-				return this.name.toLowerCase().replace(/ /g,'-').replace(/[^\w-]+/g,'');
+			get: function() {
+				return this.name.toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g, '');
 			}
 		}
 	});
 	Account.List = DefineList.extend({
-	  "*": Account,
-	  limit: "number",
-	  skip: "number",
-	  total: "number"
+		"*": Account,
+		limit: "number",
+		skip: "number",
+		total: "number"
 	});
 
 	var accounts = new Account.List([
@@ -441,13 +447,13 @@ test('list.sort a list of DefineMaps', function(){
 	]);
 	accounts.limit = 3;
 
-	var template = stache('{{#each accounts}}{{name}},{{/each}}')({accounts: accounts});
+	var template = stache('{{#each accounts}}{{name}},{{/each}}')({ accounts: accounts });
 	equal(template.textContent, "Savings,Checking,Kids Savings,", "template rendered properly.");
 
-	accounts.sort(function(a, b){
+	accounts.sort(function(a, b) {
 		if (a.name < b.name) {
 			return -1;
-		} else if (a.name > b.name){
+		} else if (a.name > b.name) {
 			return 1;
 		} else {
 			return 0;
@@ -457,10 +463,10 @@ test('list.sort a list of DefineMaps', function(){
 	equal(template.textContent, "Checking,Kids Savings,Savings,", "template updated properly.");
 
 	// Try sorting in reverse on the dynamic `slug` property
-	accounts.sort(function(a, b){
+	accounts.sort(function(a, b) {
 		if (a.slug < b.slug) {
 			return 1;
-		} else if (a.slug > b.slug){
+		} else if (a.slug > b.slug) {
 			return -1;
 		} else {
 			return 0;
@@ -472,248 +478,248 @@ test('list.sort a list of DefineMaps', function(){
 	equal(template.textContent, "Savings,Kids Savings,Checking,", "template updated properly.");
 });
 
-test('list.sort a list of objects without losing reference (#137)', function(){
-	var unSorted = new DefineList([{id: 3}, {id: 2}, {id: 1}]);
+test('list.sort a list of objects without losing reference (#137)', function() {
+	var unSorted = new DefineList([ { id: 3 }, { id: 2 }, { id: 1 } ]);
 	var sorted = unSorted.slice(0).sort(function(a, b) {
-		return a.id > b.id ? 1 : a.id < b.id ? -1 : 0;
+		return a.id > b.id ? 1 : (a.id < b.id ? -1 : 0);
 	});
 	equal(unSorted[0], sorted[2], 'items should be equal');
 });
 
-test("list defines", 6, function(){
-    var Todo = function(props){
-        assign(this, props);
-        CID(this);
-    };
-    define(Todo.prototype,{
-        completed: "boolean",
-        destroyed: {
-            value: false
-        }
-    });
-    Todo.prototype.destroy = function(){
-        this.destroyed = true;
-    };
+test("list defines", 6, function() {
+	var Todo = function(props) {
+		assign(this, props);
+		CID(this);
+	};
+	define(Todo.prototype, {
+		completed: "boolean",
+		destroyed: {
+			value: false
+		}
+	});
+	Todo.prototype.destroy = function() {
+		this.destroyed = true;
+	};
 
-    var TodoList = DefineList.extend({
+	var TodoList = DefineList.extend({
 
-    	"*": Todo,
-    	remaining: {
-    		get: function() {
-    			return this.filter({
-    				completed: false
-    			});
-    		}
-    	},
-    	completed: {
-    		get: function() {
-    			return this.filter({
-    				completed: true
-    			});
-    		}
-    	},
+		"*": Todo,
+		remaining: {
+			get: function() {
+				return this.filter({
+					completed: false
+				});
+			}
+		},
+		completed: {
+			get: function() {
+				return this.filter({
+					completed: true
+				});
+			}
+		},
 
-    	destroyCompleted: function() {
-    		this.completed.forEach(function(todo) {
-    			todo.destroy();
-    		});
-    	},
-    	setCompletedTo: function(value) {
-    		this.forEach(function(todo) {
-    			todo.completed = value;
-    		});
-    	}
-    });
+		destroyCompleted: function() {
+			this.completed.forEach(function(todo) {
+				todo.destroy();
+			});
+		},
+		setCompletedTo: function(value) {
+			this.forEach(function(todo) {
+				todo.completed = value;
+			});
+		}
+	});
 
-    var todos = new TodoList([{completed: true},{completed: false}]);
+	var todos = new TodoList([ { completed: true }, { completed: false } ]);
 
-    ok(todos.item(0) instanceof Todo, "correct instance");
-    equal(todos.completed.length, 1, "only one todo");
+	ok(todos.item(0) instanceof Todo, "correct instance");
+	equal(todos.completed.length, 1, "only one todo");
 
-    todos.on("completed", function(ev, newVal, oldVal){
-        ok(newVal instanceof TodoList, "right type");
-        equal(newVal.length, 2, "all items");
-        ok(oldVal instanceof TodoList, "right type");
-        equal(oldVal.length, 1, "all items");
-    });
+	todos.on("completed", function(ev, newVal, oldVal) {
+		ok(newVal instanceof TodoList, "right type");
+		equal(newVal.length, 2, "all items");
+		ok(oldVal instanceof TodoList, "right type");
+		equal(oldVal.length, 1, "all items");
+	});
 
-    todos.setCompletedTo(true);
-
-});
-
-QUnit.test("extending the base supports overwriting _eventSetup", function(){
-    var L = DefineList.extend({});
-    Object.getOwnPropertyDescriptor(DefineMap.prototype,"_eventSetup");
-    L.prototype.arbitraryProp = true;
-    ok(true,"set arbitraryProp");
-    L.prototype._eventSetup = function(){};
-    ok(true, "worked");
-});
-
-QUnit.test("setting expandos on a DefineList", function(){
-    var DL = DefineList.extend({
-        count: "number"
-    });
-
-    var dl = new DL();
-    dl.set({count: 5, skip: 2});
-
-    QUnit.equal( dl.get("count"), 5, "read with .get defined"); //-> 5
-    QUnit.equal( dl.count, 5, "read with . defined");
-
-    QUnit.equal( dl.get("skip"), 2, "read with .get expando");
-    QUnit.equal( dl.skip, 2, "read with . expando");
-
-    QUnit.equal( dl.get("limit"), undefined, "read with .get undefined");
-});
-
-QUnit.test("passing a DefineList to DefineList (#33)", function(){
-    var m = new DefineList([{},{}]);
-
-    var m2 = new DefineList(m);
-    QUnit.deepEqual(m.get(), m2.get());
-    QUnit.ok(m[0] === m2[0], "index the same");
-    QUnit.ok(m[1] === m2[1], "index the same");
+	todos.setCompletedTo(true);
 
 });
 
-QUnit.test("reading and setting expandos", function(){
-    var list = new DefineList();
-    var countObservation = new Observation(function(){
-        return list.get("count");
-    }, null, function(newValue){
-        QUnit.equal(newValue, 1000, "got new value");
-    });
-    countObservation.start();
-
-    list.set("count",1000);
-
-    QUnit.equal( countObservation.value, 1000);
-
-
-    var list2 = new DefineList();
-    list2.on("count", function(ev, newVal){
-        QUnit.equal(newVal, 5);
-    });
-    list2.set("count", 5);
+QUnit.test("extending the base supports overwriting _eventSetup", function() {
+	var L = DefineList.extend({});
+	Object.getOwnPropertyDescriptor(DefineMap.prototype, "_eventSetup");
+	L.prototype.arbitraryProp = true;
+	ok(true, "set arbitraryProp");
+	L.prototype._eventSetup = function() {};
+	ok(true, "worked");
 });
 
-QUnit.test("is list like", function(){
-    var list = new DefineList();
-    QUnit.ok( types.isListLike(list) );
+QUnit.test("setting expandos on a DefineList", function() {
+	var DL = DefineList.extend({
+		count: "number"
+	});
+
+	var dl = new DL();
+	dl.set({ count: 5, skip: 2 });
+
+	QUnit.equal(dl.get("count"), 5, "read with .get defined"); //-> 5
+	QUnit.equal(dl.count, 5, "read with . defined");
+
+	QUnit.equal(dl.get("skip"), 2, "read with .get expando");
+	QUnit.equal(dl.skip, 2, "read with . expando");
+
+	QUnit.equal(dl.get("limit"), undefined, "read with .get undefined");
 });
 
-QUnit.test("extending DefineList constructor functions (#61)", function(){
-  var AList = DefineList.extend('AList', { aProp: {}, aMethod: function(){} });
-  var BList = AList.extend('BList', { bProp: {}, bMethod: function(){} });
-  var CList = BList.extend('CList', { cProp: {}, cMethod: function(){} });
+QUnit.test("passing a DefineList to DefineList (#33)", function() {
+	var m = new DefineList([ {}, {} ]);
 
-  var list = new CList([{},{}]);
-
-  list.on("aProp", function(ev, newVal, oldVal){
-      QUnit.equal(newVal, "PROP");
-      QUnit.equal(oldVal, undefined);
-  });
-  list.on("bProp", function(ev, newVal, oldVal){
-      QUnit.equal(newVal, "FOO");
-      QUnit.equal(oldVal, undefined);
-  });
-  list.on("cProp", function(ev, newVal, oldVal){
-      QUnit.equal(newVal, "BAR");
-      QUnit.equal(oldVal, undefined);
-  });
-
-  list.aProp = "PROP";
-  list.bProp = 'FOO';
-  list.cProp = 'BAR';
-
-  QUnit.ok(list.aMethod);
-  QUnit.ok(list.bMethod);
-  QUnit.ok(list.cMethod);
-});
-
-QUnit.test("extending DefineList constructor functions more than once (#61)", function(){
-    var AList = DefineList.extend("AList", { aProp: {}, aMethod: function(){} });
-
-    var BList = AList.extend("BList", { bProp: {}, bMethod: function(){} });
-
-    var CList = AList.extend("CList", { cProp: {}, cMethod: function(){} });
-
-    var list1 = new BList([{},{}]);
-    var list2 = new CList([{},{},{}]);
-
-    list1.on("aProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "PROP", "aProp newVal on list1");
-        QUnit.equal(oldVal, undefined);
-    });
-    list1.on("bProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "FOO", "bProp newVal on list1");
-        QUnit.equal(oldVal, undefined);
-    });
-
-    list2.on("aProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "PROP", "aProp newVal on list2");
-        QUnit.equal(oldVal, undefined);
-    });
-    list2.on("cProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "BAR", "cProp newVal on list2");
-        QUnit.equal(oldVal, undefined);
-    });
-
-    list1.aProp = "PROP";
-    list1.bProp = 'FOO';
-    list2.aProp = "PROP";
-    list2.cProp = 'BAR';
-    QUnit.ok(list1.aMethod, "list1 aMethod");
-    QUnit.ok(list1.bMethod);
-    QUnit.ok(list2.aMethod);
-    QUnit.ok(list2.cMethod, "list2 cMethod");
-});
-
-QUnit.test("extending DefineList constructor functions - value (#61)", function(){
-    var AList = DefineList.extend("AList", { aProp: {value: 1} });
-
-    var BList = AList.extend("BList", { });
-
-    var CList = BList.extend("CList",{ });
-
-    var c = new CList([]);
-    QUnit.equal( c.aProp , 1 ,"got initial value" );
-});
-
-QUnit.test("'*' inheritance works (#61)", function(){
-    var Account = DefineMap.extend({
-        name: "string",
-        amount: "number",
-      	slug: {
-      		serialize: true,
-      		get: function() {
-      			return this.name.toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g, '');
-      		}
-      	}
-    });
-
-    var BaseList = DefineList.extend({
-        "*": Account
-    });
-
-    var ExtendedList = BaseList.extend({});
-
-    var xl = new ExtendedList([{}]);
-
-    QUnit.ok(xl[0] instanceof Account);
+	var m2 = new DefineList(m);
+	QUnit.deepEqual(m.get(), m2.get());
+	QUnit.ok(m[0] === m2[0], "index the same");
+	QUnit.ok(m[1] === m2[1], "index the same");
 
 });
 
-QUnit.test("shorthand getter setter (#56)", function(){
+QUnit.test("reading and setting expandos", function() {
+	var list = new DefineList();
+	var countObservation = new Observation(function() {
+		return list.get("count");
+	}, null, function(newValue) {
+		QUnit.equal(newValue, 1000, "got new value");
+	});
+	countObservation.start();
 
-    var People = DefineList.extend({
+	list.set("count", 1000);
+
+	QUnit.equal(countObservation.value, 1000);
+
+
+	var list2 = new DefineList();
+	list2.on("count", function(ev, newVal) {
+		QUnit.equal(newVal, 5);
+	});
+	list2.set("count", 5);
+});
+
+QUnit.test("is list like", function() {
+	var list = new DefineList();
+	QUnit.ok(types.isListLike(list));
+});
+
+QUnit.test("extending DefineList constructor functions (#61)", function() {
+	var AList = DefineList.extend('AList', { aProp: {}, aMethod: function() {} });
+	var BList = AList.extend('BList', { bProp: {}, bMethod: function() {} });
+	var CList = BList.extend('CList', { cProp: {}, cMethod: function() {} });
+
+	var list = new CList([ {}, {} ]);
+
+	list.on("aProp", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "PROP");
+		QUnit.equal(oldVal, undefined);
+	});
+	list.on("bProp", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "FOO");
+		QUnit.equal(oldVal, undefined);
+	});
+	list.on("cProp", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "BAR");
+		QUnit.equal(oldVal, undefined);
+	});
+
+	list.aProp = "PROP";
+	list.bProp = 'FOO';
+	list.cProp = 'BAR';
+
+	QUnit.ok(list.aMethod);
+	QUnit.ok(list.bMethod);
+	QUnit.ok(list.cMethod);
+});
+
+QUnit.test("extending DefineList constructor functions more than once (#61)", function() {
+	var AList = DefineList.extend("AList", { aProp: {}, aMethod: function() {} });
+
+	var BList = AList.extend("BList", { bProp: {}, bMethod: function() {} });
+
+	var CList = AList.extend("CList", { cProp: {}, cMethod: function() {} });
+
+	var list1 = new BList([ {}, {} ]);
+	var list2 = new CList([ {}, {}, {} ]);
+
+	list1.on("aProp", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "PROP", "aProp newVal on list1");
+		QUnit.equal(oldVal, undefined);
+	});
+	list1.on("bProp", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "FOO", "bProp newVal on list1");
+		QUnit.equal(oldVal, undefined);
+	});
+
+	list2.on("aProp", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "PROP", "aProp newVal on list2");
+		QUnit.equal(oldVal, undefined);
+	});
+	list2.on("cProp", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "BAR", "cProp newVal on list2");
+		QUnit.equal(oldVal, undefined);
+	});
+
+	list1.aProp = "PROP";
+	list1.bProp = 'FOO';
+	list2.aProp = "PROP";
+	list2.cProp = 'BAR';
+	QUnit.ok(list1.aMethod, "list1 aMethod");
+	QUnit.ok(list1.bMethod);
+	QUnit.ok(list2.aMethod);
+	QUnit.ok(list2.cMethod, "list2 cMethod");
+});
+
+QUnit.test("extending DefineList constructor functions - value (#61)", function() {
+	var AList = DefineList.extend("AList", { aProp: { value: 1 } });
+
+	var BList = AList.extend("BList", { });
+
+	var CList = BList.extend("CList", { });
+
+	var c = new CList([]);
+	QUnit.equal(c.aProp, 1, "got initial value");
+});
+
+QUnit.test("'*' inheritance works (#61)", function() {
+	var Account = DefineMap.extend({
+		name: "string",
+		amount: "number",
+		slug: {
+			serialize: true,
+			get: function() {
+				return this.name.toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g, '');
+			}
+		}
+	});
+
+	var BaseList = DefineList.extend({
+		"*": Account
+	});
+
+	var ExtendedList = BaseList.extend({});
+
+	var xl = new ExtendedList([ {} ]);
+
+	QUnit.ok(xl[0] instanceof Account);
+
+});
+
+QUnit.test("shorthand getter setter (#56)", function() {
+
+	var People = DefineList.extend({
 		first: "*",
 		last: "*",
 		get fullName() {
 			return this.first + " " + this.last;
 		},
-		set fullName(newVal){
+		set fullName(newVal) {
 			var parts = newVal.split(" ");
 			this.first = parts[0];
 			this.last = parts[1];
@@ -721,7 +727,7 @@ QUnit.test("shorthand getter setter (#56)", function(){
 	});
 
 	var p = new People([]);
-    p.fullName = "Mohamed Cherif";
+	p.fullName = "Mohamed Cherif";
 
 	p.on("fullName", function(ev, newVal, oldVal) {
 		QUnit.equal(oldVal, "Mohamed Cherif");
@@ -744,14 +750,14 @@ QUnit.test("added and removed are called after items are added/removed (#14)", f
 
 	var People = DefineList.extend({
 		"#": {
-			added: function(items, index){
+			added: function(items, index) {
 				addedFuncCalled = true;
 				ok(items, "items added got passed to added");
 				ok(typeof index === 'number', "index of items was passed to added and is a number");
 				ok(items[0].name === 'John', "Name was correct");
 				theList = this;
 			},
-			removed: function(items, index){
+			removed: function(items, index) {
 				removedFuncCalled = true;
 				ok(items, "items added got passed to removed");
 				ok(typeof index === 'number', "index of items was passed to removed and is a number");
@@ -783,35 +789,35 @@ QUnit.test("added and removed are called after items are added/removed (#14)", f
 		"the list was passed correctly as this to removed");
 });
 
-QUnit.test("* vs # (#78)", function(){
+QUnit.test("* vs # (#78)", function() {
 
-    var MyList = DefineList.extend({
-        "*": "number",
-        "#": {
-            added: function(){
-                ok(true, "called on init");
-            },
-            removed: function(){},
-            type: "string"
-        }
-    });
+	var MyList = DefineList.extend({
+		"*": "number",
+		"#": {
+			added: function() {
+				ok(true, "called on init");
+			},
+			removed: function() {},
+			type: "string"
+		}
+	});
 
-    var list = new MyList([1,2,3]);
+	var list = new MyList([ 1, 2, 3 ]);
 
-    QUnit.ok(list[0] === "1", "converted to string");
-    list.set("prop", "4");
-    QUnit.ok(list.prop === 4, "type converted");
+	QUnit.ok(list[0] === "1", "converted to string");
+	list.set("prop", "4");
+	QUnit.ok(list.prop === 4, "type converted");
 
 });
 
-QUnit.test("Array shorthand uses #", function(){
-    var MyMap = DefineMap.extend({
-        "numbers": ["number"]
-    });
+QUnit.test("Array shorthand uses #", function() {
+	var MyMap = DefineMap.extend({
+		"numbers": [ "number" ]
+	});
 
-    var map = new MyMap({numbers: ["1","2"]});
-    QUnit.ok(map.numbers[0] === 1, "converted to number");
+	var map = new MyMap({ numbers: [ "1", "2" ] });
+	QUnit.ok(map.numbers[0] === 1, "converted to number");
 
-    map.numbers.set("prop", "4");
-    QUnit.ok(map.numbers.prop === "4", "type left alone");
+	map.numbers.set("prop", "4");
+	QUnit.ok(map.numbers.prop === "4", "type left alone");
 });

--- a/list/list-test.js
+++ b/list/list-test.js
@@ -822,7 +822,7 @@ QUnit.test("Array shorthand uses #", function() {
 	QUnit.ok(map.numbers.prop === "4", "type left alone");
 });
 
-test("replace-with-self lists are diffed properly", function() {
+test("replace-with-self lists are diffed properly (can-view-live#10)", function() {
 	var a = new DefineMap({ name: "A" });
 	var b = new DefineMap({ name: "B" });
 	var c = new DefineMap({ name: "C" });

--- a/list/list.js
+++ b/list/list.js
@@ -894,12 +894,14 @@ assign(DefineList.prototype, {
 	replace: function(newList) {
 		var patches = diff(this, newList);
 
+		canBatch.start();
 		for (var i = 0, len = patches.length; i < len; i++) {
 			this.splice.apply(this, [
 				patches[i].index,
 				patches[i].deleteCount
 			].concat(patches[i].insert));
 		}
+		canBatch.stop();
 
 		return this;
 	},

--- a/list/list.js
+++ b/list/list.js
@@ -9,6 +9,7 @@ var canLog = require("can-util/js/log/log");
 var defineHelpers = require("../define-helpers/define-helpers");
 
 var assign = require("can-util/js/assign/assign");
+var diff = require("can-util/js/diff/diff");
 var each = require("can-util/js/each/each");
 var isArray = require("can-util/js/is-array/is-array");
 var makeArray = require("can-util/js/make-array/make-array");
@@ -891,7 +892,15 @@ assign(DefineList.prototype, {
 	 * `replace` causes _remove_, _add_, and _length_ events.
 	 */
 	replace: function(newList) {
-		this.splice.apply(this, [ 0, this._length ].concat(makeArray(newList || [])));
+		var patches = diff(this, newList);
+
+		for (var i = 0, len = patches.length; i < len; i++) {
+			this.splice.apply(this, [
+				patches[i].index,
+				patches[i].deleteCount
+			].concat(patches[i].insert));
+		}
+
 		return this;
 	},
 

--- a/list/list.js
+++ b/list/list.js
@@ -71,7 +71,7 @@ var DefineList = Construct.extend("DefineList",
 			define.setup.call(this, {}, false);
 			this._length = 0;
 			if (items) {
-				this.splice.apply(this, [0, 0].concat(defineHelpers.toObject(this, items, [], DefineList)));
+				this.splice.apply(this, [ 0, 0 ].concat(defineHelpers.toObject(this, items, [], DefineList)));
 			}
 		},
 		__type: define.types.observable,
@@ -90,22 +90,22 @@ var DefineList = Construct.extend("DefineList",
 					if (itemsDefinition && typeof itemsDefinition.added === 'function') {
 						Observation.ignore(itemsDefinition.added).call(this, newVal, index);
 					}
-					canEvent.dispatch.call(this, how, [newVal, index]);
-					canEvent.dispatch.call(this, 'length', [this._length]);
+					canEvent.dispatch.call(this, how, [ newVal, index ]);
+					canEvent.dispatch.call(this, 'length', [ this._length ]);
 				} else if (how === 'remove') {
 					if (itemsDefinition && typeof itemsDefinition.removed === 'function') {
 						Observation.ignore(itemsDefinition.removed).call(this, oldVal, index);
 					}
-					canEvent.dispatch.call(this, how, [oldVal, index]);
-					canEvent.dispatch.call(this, 'length', [this._length]);
+					canEvent.dispatch.call(this, how, [ oldVal, index ]);
+					canEvent.dispatch.call(this, 'length', [ this._length ]);
 				} else {
-					canEvent.dispatch.call(this, how, [newVal, index]);
+					canEvent.dispatch.call(this, how, [ newVal, index ]);
 				}
 			} else {
 				canEvent.dispatch.call(this, {
 					type: "" + attr,
 					target: this
-				}, [newVal, oldVal]);
+				}, [ newVal, oldVal ]);
 			}
 
 			canBatch.stop();
@@ -121,7 +121,8 @@ var DefineList = Construct.extend("DefineList",
 		 * Returns the list converted into a plain JS array. Any items that also have a
 		 * `get` method will have their `get` method called and the resulting value will be used as item value.
 		 *
-		 * This can be used to recursively convert a list instance to an Array of other plain JavaScript objects. Cycles are supported and only create one object.
+		 * This can be used to recursively convert a list instance to an Array of other plain JavaScript objects.
+		 * Cycles are supported and only create one object.
 		 *
 		 * `get()` can still return other non-plain JS objects like Dates.
 		 * Use [can-define/map/map.prototype.serialize] when a form proper for `JSON.stringify` is needed.
@@ -263,7 +264,7 @@ var DefineList = Construct.extend("DefineList",
 					if (value) {
 						this.replace(prop);
 					} else {
-						this.splice.apply(this, [0, prop.length].concat(prop));
+						this.splice.apply(this, [ 0, prop.length ].concat(prop));
 					}
 				} else {
 					each(prop, function(value, prop) {
@@ -285,7 +286,7 @@ var DefineList = Construct.extend("DefineList",
 				callback(this[i], i);
 			}
 		},
-		//
+
 		/**
 		 * @function can-define/list/list.prototype.splice splice
 		 * @parent can-define/list/list.prototype
@@ -374,6 +375,7 @@ var DefineList = Construct.extend("DefineList",
 			canBatch.stop();
 			return removed;
 		},
+
 		/**
 		 * @function can-define/list/list.prototype.serialize serialize
 		 * @parent can-define/list/list.prototype
@@ -461,7 +463,7 @@ each({
 		 * `push` has a counterpart in [can-define/list/list::pop pop], or you may be
 		 * looking for [can-define/list/list::unshift unshift] and its counterpart [can-define/list/list::shift shift].
 		 */
-		push: "length",
+	push: "length",
 		/**
 		 * @function can-define/list/list.prototype.unshift unshift
 		 * @description Add items to the beginning of a DefineList.
@@ -506,8 +508,8 @@ each({
 		 * `unshift` has a counterpart in [can-define/list/list::shift shift], or you may be
 		 * looking for [can-define/list/list::push push] and its counterpart [can-define/list/list::pop pop].
 		 */
-		unshift: 0
-	},
+	unshift: 0
+},
 	// Adds a method
 	// `name` - The method name.
 	// `where` - Where items in the `array` should be added.
@@ -579,7 +581,7 @@ each({
 		 * `pop` has its counterpart in [can-define/list/list::push push], or you may be
 		 * looking for [can-define/list/list::unshift unshift] and its counterpart [can-define/list/list::shift shift].
 		 */
-		pop: "length",
+	pop: "length",
 		/**
 		 * @function can-define/list/list.prototype.shift shift
 		 * @description Remove an item from the front of a list.
@@ -612,8 +614,8 @@ each({
 		 * `shift` has a counterpart in [can-define/list/list::unshift unshift], or you may be
 		 * looking for [can-define/list/list::push push] and its counterpart [can-define/list/list::pop pop].
 		 */
-		shift: 0
-	},
+	shift: 0
+},
 	// Creates a `remove` type method
 	function(where, name) {
 		DefineList.prototype[name] = function() {
@@ -633,7 +635,7 @@ each({
 			// `remove` - Items removed.
 			// `undefined` - The new values (there are none).
 			// `res` - The old, removed values (should these be unbound).
-			this._triggerChange("" + len, "remove", undefined, [res]);
+			this._triggerChange("" + len, "remove", undefined, [ res ]);
 
 			return res;
 		};
@@ -889,9 +891,10 @@ assign(DefineList.prototype, {
 	 * `replace` causes _remove_, _add_, and _length_ events.
 	 */
 	replace: function(newList) {
-		this.splice.apply(this, [0, this._length].concat(makeArray(newList || [])));
+		this.splice.apply(this, [ 0, this._length ].concat(makeArray(newList || [])));
 		return this;
 	},
+
 	/**
 	 * @function can-define/list/list.prototype.filter filter
 	 *
@@ -953,6 +956,7 @@ assign(DefineList.prototype, {
 		});
 		return new this.constructor(filteredList);
 	},
+
 	/**
 	 * @function can-define/list/list.prototype.map map
 	 * @description Map the values in this list to another list.
@@ -996,6 +1000,7 @@ assign(DefineList.prototype, {
 		});
 		return new this.constructor(mappedList);
 	},
+
 	/**
 	 * @function can-define/list/list.prototype.sort sort
 	 * @description Sort the properties of a list.
@@ -1046,14 +1051,13 @@ assign(DefineList.prototype, {
 		var added = Array.prototype.slice.call(this);
 
 		canBatch.start();
-		canEvent.dispatch.call(this, 'remove', [removed, 0]);
-		canEvent.dispatch.call(this, 'add', [added, 0]);
-		canEvent.dispatch.call(this, 'length', [this._length, this._length]);
+		canEvent.dispatch.call(this, 'remove', [ removed, 0 ]);
+		canEvent.dispatch.call(this, 'add', [ added, 0 ]);
+		canEvent.dispatch.call(this, 'length', [ this._length, this._length ]);
 		canBatch.stop();
 		return this;
 	}
 });
-
 
 
 // Add necessary event methods to this object.


### PR DESCRIPTION
DefineList::replace uses can-util/diff to optimize changes (rather than dumping and reinserting everything, as before). Resolves canjs/can-view-live#10

The tests feel a bit off, as it is essentially testing the result of the diff, rather than that can-util/diff was used. It does test that it's not a blanket replace, however.