### PR TITLE
make Map and List iterable

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,21 +1,21 @@
 var stealTools = require("steal-tools");
 
 stealTools.export({
-    steal: {
-        main: ["can-define", "can-define/map/map", "can-define/list/list"],
-        config: __dirname + "/package.json!npm"
-    },
-    outputs: {
-        "+amd": {},
-        "+standalone": {
-          modules: ["can-define", "can-define/map/map", "can-define/list/list"],
-          exports: {
-            "can-namespace": "can"
-          }
-        }
-    }
-}).catch(function(e){
-    setTimeout(function(){
-        throw e;
-    }, 1);
+	steal: {
+		main: [ "can-define", "can-define/map/map", "can-define/list/list" ],
+		config: __dirname + "/package.json!npm"
+	},
+	outputs: {
+		"+amd": {},
+		"+standalone": {
+			modules: [ "can-define", "can-define/map/map", "can-define/list/list" ],
+			exports: {
+				"can-namespace": "can"
+			}
+		}
+	}
+}).catch(function(e) {
+	setTimeout(function() {
+		throw e;
+	}, 1);
 });

--- a/can-define.js
+++ b/can-define.js
@@ -34,10 +34,10 @@ var defineConfigurableAndNotEnumerable = function(obj, prop, value) {
 	});
 };
 
-var eachPropertyDescriptor = function(map, cb){
-	for(var prop in map) {
-		if(map.hasOwnProperty(prop)) {
-			cb(prop, Object.getOwnPropertyDescriptor(map,prop));
+var eachPropertyDescriptor = function(map, cb) {
+	for (var prop in map) {
+		if (map.hasOwnProperty(prop)) {
+			cb(prop, Object.getOwnPropertyDescriptor(map, prop));
 		}
 	}
 };
@@ -55,7 +55,7 @@ module.exports = define = ns.define = function(objPrototype, defines, baseDefine
 
 	// Goes through each property definition and creates
 	// a `getter` and `setter` function for `Object.defineProperty`.
-	each(result.definitions, function(definition, property){
+	each(result.definitions, function(definition, property) {
 		define.property(objPrototype, property, definition, dataInitializers, computedInitializers);
 	});
 
@@ -94,7 +94,7 @@ module.exports = define = ns.define = function(objPrototype, defines, baseDefine
 		});
 	}
 	// add so instance defs can be dynamically added
-	Object.defineProperty(objPrototype,"_define",{
+	Object.defineProperty(objPrototype, "_define", {
 		enumerable: false,
 		value: result,
 		configurable: true,
@@ -103,8 +103,8 @@ module.exports = define = ns.define = function(objPrototype, defines, baseDefine
 
 	// Places Symbol.iterator or @@iterator on the prototype
 	// so that this can be iterated with for/of and can-util/js/each/each
-	if(!objPrototype[types.iterator]) {
-		defineConfigurableAndNotEnumerable(objPrototype, types.iterator, function(){
+	if (!objPrototype[types.iterator]) {
+		defineConfigurableAndNotEnumerable(objPrototype, types.iterator, function() {
 			return new define.Iterator(this);
 		});
 	}
@@ -112,11 +112,11 @@ module.exports = define = ns.define = function(objPrototype, defines, baseDefine
 	return result;
 };
 
-define.extensions = function () {};
+define.extensions = function() {};
 
-var onlyType = function(obj){
-	for(var prop in obj) {
-		if(prop !== "type") {
+var onlyType = function(obj) {
+	for (var prop in obj) {
+		if (prop !== "type") {
 			return false;
 		}
 	}
@@ -177,7 +177,7 @@ define.property = function(objPrototype, prop, definition, dataInitializers, com
 	if ((definition.value !== undefined || definition.Value !== undefined)) {
 		getInitialValue = Observation.ignore(make.get.defaultValue(prop, definition, typeConvert, eventsSetter));
 	}
-	
+
 	// If property has a getter, create the compute that stores its data.
 	if (definition.get) {
 		computedInitializers[prop] = make.compute(prop, definition.get, getInitialValue);
@@ -247,7 +247,8 @@ make = {
 				computeFn = defaultValue.isComputed ?
 					defaultValue :
 					compute.async(defaultValue, get, map);
-			} else {
+			}
+			else {
 				computeFn = compute.async(defaultValue, get, map);
 			}
 
@@ -258,7 +259,7 @@ make = {
 					canEvent.dispatch.call(map, {
 						type: prop,
 						target: map
-					}, [newVal, oldVal]);
+					}, [ newVal, oldVal ]);
 				}
 			};
 		};
@@ -284,11 +285,11 @@ make = {
 					var current = getCurrent.call(this);
 					if (newVal !== current) {
 						setData.call(this, newVal);
-						
+
 						canEvent.dispatch.call(this, {
 							type: prop,
 							target: this
-						}, [newVal, current]);
+						}, [ newVal, current ]);
 					}
 				}
 			};
@@ -319,7 +320,8 @@ make = {
 
 				if (setterCalled) {
 					canBatch.stop();
-				} else {
+				}
+				else {
 					if (hasGetter) {
 						// we got a return value
 						if (setValue !== undefined) {
@@ -354,7 +356,8 @@ make = {
 							canBatch.stop();
 							return;
 						}
-					} else {
+					}
+					else {
 						// we got a return value
 						if (setValue !== undefined) {
 							// if the current `set` value is returned, don't set
@@ -398,7 +401,8 @@ make = {
 
 				return make.set.Type(prop, type, set);
 
-			} else {
+			}
+			else {
 				return function(newValue) {
 					return set.call(this, type.call(this, newValue, prop));
 				};
@@ -406,21 +410,24 @@ make = {
 		},
 		Type: function(prop, Type, set) {
 			// `type`: {foo: "string"}
-			if(isArray(Type) && types.DefineList) {
+			if (isArray(Type) && types.DefineList) {
 				Type = types.DefineList.extend({
 					"#": Type[0]
 				});
-			} else if (typeof Type === "object") {
-				if(types.DefineMap) {
+			}
+			else if (typeof Type === "object") {
+				if (types.DefineMap) {
 					Type = types.DefineMap.extend(Type);
-				} else {
+				}
+				else {
 					Type = define.constructor(Type);
 				}
 			}
 			return function(newValue) {
 				if (newValue instanceof Type || newValue == null) {
 					return set.call(this, newValue);
-				} else {
+				}
+				else {
 					return set.call(this, new Type(newValue));
 				}
 			};
@@ -477,23 +484,24 @@ make = {
 						value = typeConvert(new Value());
 					}
 				}
-				if(definition.set) {
+				if (definition.set) {
 					// TODO: there's almost certainly a faster way of making this happen
 					// But this is maintainable.
 
 					var VALUE;
 					var sync = true;
 
-					var setter = make.set.setter(prop, definition.set, function(){}, function(value){
-						if(sync) {
+					var setter = make.set.setter(prop, definition.set, function() {}, function(value) {
+						if (sync) {
 							VALUE = value;
-						} else {
+						}
+						else {
 							callSetter.call(this, value);
 						}
 					}, definition.get);
 
-					setter.call(this,value);
-					sync= false;
+					setter.call(this, value);
+					sync = false;
 
 					// VALUE will be undefined if the callback is never called.
 					return VALUE;
@@ -508,7 +516,7 @@ make = {
 				if (!this.__inSetup) {
 					Observation.add(this, prop);
 				}
-				
+
 				return this._data[prop];
 			};
 		},
@@ -520,14 +528,14 @@ make = {
 	}
 };
 
-define.behaviors = ["get", "set", "value", "Value", "type", "Type", "serialize"];
+define.behaviors = [ "get", "set", "value", "Value", "type", "Type", "serialize" ];
 
 var addDefinition = function(definition, behavior, value) {
-	if(behavior === "type") {
+	if (behavior === "type") {
 		var behaviorDef = value;
-		if(typeof behaviorDef === "string") {
+		if (typeof behaviorDef === "string") {
 			behaviorDef = define.types[behaviorDef];
-			if(typeof behaviorDef === "object") {
+			if (typeof behaviorDef === "object") {
 				assign(definition, behaviorDef);
 				behaviorDef = behaviorDef[behavior];
 			}
@@ -546,46 +554,50 @@ makeDefinition = function(prop, def, defaultDefinition) {
 		addDefinition(definition, behavior, value);
 	});
 	// only add default if it doesn't exist
-	each(defaultDefinition, function(value, prop){
-		if(definition[prop] === undefined) {
-			if(prop !== "type" && prop !== "Type") {
+	each(defaultDefinition, function(value, prop) {
+		if (definition[prop] === undefined) {
+			if (prop !== "type" && prop !== "Type") {
 				definition[prop] = value;
 			}
 		}
 	});
 	// if there's no type definition, take it from the defaultDefinition
-	if(!definition.type && !definition.Type) {
+	if (!definition.type && !definition.Type) {
 		defaults(definition, defaultDefinition);
 	}
 
 
-	if( isEmptyObject(definition) ) {
+	if (isEmptyObject(definition)) {
 		definition.type = define.types["*"];
 	}
 	return definition;
 };
 
-getDefinitionOrMethod = function(prop, value, defaultDefinition){
+getDefinitionOrMethod = function(prop, value, defaultDefinition) {
 	var definition;
-	if(typeof value === "string") {
-		definition = {type: value};
+	if (typeof value === "string") {
+		definition = { type: value };
 	}
-	else if(typeof value === "function") {
-		if(types.isConstructor(value)) {
-			definition = {Type: value};
-		} else if(isDefineType(value)) {
-			definition = {type: value};
+	else if (typeof value === "function") {
+		if (types.isConstructor(value)) {
+			definition = { Type: value };
+		}
+		else if (isDefineType(value)) {
+			definition = { type: value };
 		}
 		// or leaves as a function
-	} else if( isArray(value) ) {
-		definition = {Type: value};
-	} else if( isPlainObject(value) ){
+	}
+	else if (isArray(value)) {
+		definition = { Type: value };
+	}
+	else if (isPlainObject(value)) {
 		definition = value;
 	}
 
-	if(definition) {
+	if (definition) {
 		return makeDefinition(prop, definition, defaultDefinition);
-	} else {
+	}
+	else {
 		return value;
 	}
 };
@@ -596,38 +608,42 @@ getDefinitionsAndMethods = function(defines, baseDefines) {
 	// first lets get a default if it exists
 	var defaults = defines["*"],
 		defaultDefinition;
-	if(defaults) {
+	if (defaults) {
 		delete defines["*"];
 		defaultDefinition = getDefinitionOrMethod("*", defaults, {});
-	} else {
+	}
+	else {
 		defaultDefinition = {};
 	}
 
-	eachPropertyDescriptor(defines, function( prop, propertyDescriptor ) {
+	eachPropertyDescriptor(defines, function(prop, propertyDescriptor) {
 
 		var value;
-		if(propertyDescriptor.get || propertyDescriptor.set) {
-			value = {get: propertyDescriptor.get, set: propertyDescriptor.set};
-		} else {
+		if (propertyDescriptor.get || propertyDescriptor.set) {
+			value = { get: propertyDescriptor.get, set: propertyDescriptor.set };
+		}
+		else {
 			value = propertyDescriptor.value;
 		}
 
-		if(prop === "constructor") {
+		if (prop === "constructor") {
 			methods[prop] = value;
 			return;
-		} else {
+		}
+		else {
 			var result = getDefinitionOrMethod(prop, value, defaultDefinition);
-			if(result && typeof result === "object") {
+			if (result && typeof result === "object") {
 				definitions[prop] = result;
-			} else {
+			}
+			else {
 				methods[prop] = result;
 			}
 		}
 	});
-	if(defaults) {
+	if (defaults) {
 		defines["*"] = defaults;
 	}
-	return {definitions: definitions, methods: methods, defaultDefinition: defaultDefinition};
+	return { definitions: definitions, methods: methods, defaultDefinition: defaultDefinition };
 };
 
 replaceWith = function(obj, prop, cb, writable) {
@@ -659,7 +675,8 @@ assign(eventsProto, {
 			if (!computedBinding.count) {
 				computedBinding.count = 1;
 				computedBinding.compute.addEventListener("change", computedBinding.handler);
-			} else {
+			}
+			else {
 				computedBinding.count++;
 			}
 
@@ -678,7 +695,8 @@ assign(eventsProto, {
 			if (computedBinding.count === 1) {
 				computedBinding.count = 0;
 				computedBinding.compute.removeEventListener("change", computedBinding.handler);
-			} else {
+			}
+			else {
 				computedBinding.count--;
 			}
 
@@ -702,10 +720,11 @@ define.setup = function(props, sealed) {
 	var definitions = this._define.definitions;
 	var instanceDefinitions = {};
 	var map = this;
-	each(props, function(value, prop){
-		if(definitions[prop]) {
+	each(props, function(value, prop) {
+		if (definitions[prop]) {
 			map[prop] = value;
-		} else {
+		}
+		else {
 			var def = define.makeSimpleGetterSetter(prop);
 			instanceDefinitions[prop] = {};
 			Object.defineProperty(map, prop, def);
@@ -713,14 +732,14 @@ define.setup = function(props, sealed) {
 			map[prop] = define.types.observable(value);
 		}
 	});
-	if(!isEmptyObject(instanceDefinitions)) {
+	if (!isEmptyObject(instanceDefinitions)) {
 		defineConfigurableAndNotEnumerable(this, "_instanceDefinitions", instanceDefinitions);
 	}
 	// only seal in dev mode for performance reasons.
 	//!steal-remove-start
 	this._data;
 	this._computed;
-	if(sealed !== false) {
+	if (sealed !== false) {
 		Object.seal(this);
 	}
 	//!steal-remove-end
@@ -731,14 +750,14 @@ define.defineConfigurableAndNotEnumerable = defineConfigurableAndNotEnumerable;
 define.make = make;
 define.getDefinitionOrMethod = getDefinitionOrMethod;
 var simpleGetterSetters = {};
-define.makeSimpleGetterSetter = function(prop){
-	if(!simpleGetterSetters[prop]) {
+define.makeSimpleGetterSetter = function(prop) {
+	if (!simpleGetterSetters[prop]) {
 
-		var setter = make.set.events(prop, make.get.data(prop), make.set.data(prop), make.eventType.data(prop) );
+		var setter = make.set.events(prop, make.get.data(prop), make.set.data(prop), make.eventType.data(prop));
 
 		simpleGetterSetters[prop] = {
 			get: make.get.data(prop),
-			set: function(newVal){
+			set: function(newVal) {
 				return setter.call(this, define.types.observable(newVal));
 			},
 			enumerable: true
@@ -747,44 +766,46 @@ define.makeSimpleGetterSetter = function(prop){
 	return simpleGetterSetters[prop];
 };
 
-define.Iterator = function(obj){
-  this.obj = obj;
-  this.definitions = Object.keys(obj._define.definitions);
-  this.instanceDefinitions = obj._instanceDefinitions ?
-    Object.keys(obj._instanceDefinitions) :
-    Object.keys(obj);
-  this.hasGet = typeof obj.get === "function";
+define.Iterator = function(obj) {
+	this.obj = obj;
+	this.definitions = Object.keys(obj._define.definitions);
+	this.instanceDefinitions = obj._instanceDefinitions ?
+		Object.keys(obj._instanceDefinitions) :
+		Object.keys(obj);
+	this.hasGet = typeof obj.get === "function";
 };
 
-define.Iterator.prototype.next = function(){
-  var key;
-  if(this.definitions.length) {
-    key = this.definitions.shift();
+define.Iterator.prototype.next = function() {
+	var key;
+	if (this.definitions.length) {
+		key = this.definitions.shift();
 
     // Getters should not be enumerable
-    var def = this.obj._define.definitions[key];
-    if(def.get) {
-      return this.next();
-    }
-  } else if(this.instanceDefinitions.length) {
-    key = this.instanceDefinitions.shift();
-  } else {
-    return {
-      value: undefined,
-      done: true
-    };
-  }
+		var def = this.obj._define.definitions[key];
+		if (def.get) {
+			return this.next();
+		}
+	}
+	else if (this.instanceDefinitions.length) {
+		key = this.instanceDefinitions.shift();
+	}
+	else {
+		return {
+			value: undefined,
+			done: true
+		};
+	}
 
-  return {
-    value: [
-      key,
-      this.hasGet ? this.obj.get(key) : this.obj[key]
-    ],
-    done: false
-  };
+	return {
+		value: [
+			key,
+			this.hasGet ? this.obj.get(key) : this.obj[key]
+		],
+		done: false
+	};
 };
 
-isDefineType = function(func){
+isDefineType = function(func) {
 	return func && func.canDefineType === true;
 };
 
@@ -794,9 +815,11 @@ define.types = {
 		if (type === 'string') {
 			str = Date.parse(str);
 			return isNaN(str) ? null : new Date(str);
-		} else if (type === 'number') {
+		}
+		else if (type === 'number') {
 			return new Date(str);
-		} else {
+		}
+		else {
 			return str;
 		}
 	},
@@ -807,7 +830,7 @@ define.types = {
 		return +(val);
 	},
 	'boolean': function(val) {
-		if(val == null) {
+		if (val == null) {
 			return val;
 		}
 		if (val === 'false' || val === '0' || !val) {
@@ -816,19 +839,19 @@ define.types = {
 		return true;
 	},
 	'observable': function(newVal) {
-				if(isArray(newVal) && types.DefineList) {
-						newVal = new types.DefineList(newVal);
-				}
-				else if(isPlainObject(newVal) &&  types.DefineMap) {
-						newVal = new types.DefineMap(newVal);
-				}
-				return newVal;
-		},
+		if (isArray(newVal) && types.DefineList) {
+			newVal = new types.DefineList(newVal);
+		}
+		else if (isPlainObject(newVal) &&  types.DefineMap) {
+			newVal = new types.DefineMap(newVal);
+		}
+		return newVal;
+	},
 	'stringOrObservable': function(newVal) {
-		if(isArray(newVal)) {
+		if (isArray(newVal)) {
 			return new types.DefaultList(newVal);
 		}
-		else if(isPlainObject(newVal)) {
+		else if (isPlainObject(newVal)) {
 			return new types.DefaultMap(newVal);
 		}
 		else {

--- a/define-helpers/define-helpers.js
+++ b/define-helpers/define-helpers.js
@@ -6,76 +6,78 @@ var canBatch = require("can-event/batch/batch");
 var canEvent = require("can-event");
 
 
-var hasMethod = function(obj, method){
-    return obj && typeof obj === "object" && (method in obj);
+var hasMethod = function(obj, method) {
+	return obj && typeof obj === "object" && (method in obj);
 };
 
 var defineHelpers = {
-    extendedSetup: function(props){
-        assign(this, props);
-    },
-    toObject: function(map, props, where, Type){
-        if(props instanceof Type) {
-            props.each(function(value, prop){
-                where[prop] = value;
-            });
-            return where;
-        } else {
-            return props;
-        }
-    },
-    defineExpando: function(map, prop, value) {
+	extendedSetup: function(props) {
+		assign(this, props);
+	},
+	toObject: function(map, props, where, Type) {
+		if (props instanceof Type) {
+			props.each(function(value, prop) {
+				where[prop] = value;
+			});
+			return where;
+		}
+		else {
+			return props;
+		}
+	},
+	defineExpando: function(map, prop, value) {
         // first check if it's already a constructor define
-        var constructorDefines = map._define.definitions;
-        if(constructorDefines && constructorDefines[prop]) {
-            return;
-        }
+		var constructorDefines = map._define.definitions;
+		if (constructorDefines && constructorDefines[prop]) {
+			return;
+		}
         // next if it's already on this instances
-        var instanceDefines = map._instanceDefinitions;
-        if(!instanceDefines) {
-            instanceDefines = map._instanceDefinitions = {};
-        }
-        if(!instanceDefines[prop]) {
-            var defaultDefinition = map._define.defaultDefinition || {type: define.types.observable};
-            define.property(map, prop, defaultDefinition, {},{});
+		var instanceDefines = map._instanceDefinitions;
+		if (!instanceDefines) {
+			instanceDefines = map._instanceDefinitions = {};
+		}
+		if (!instanceDefines[prop]) {
+			var defaultDefinition = map._define.defaultDefinition || { type: define.types.observable };
+			define.property(map, prop, defaultDefinition, {}, {});
             // possibly convert value to List or DefineMap
-            map._data[prop] = defaultDefinition.type ? defaultDefinition.type(value) : define.types.observable(value);
-            instanceDefines[prop] = defaultDefinition;
-            canBatch.start();
-            canEvent.dispatch.call(map, {
-                type: "__keys",
-                target: map
-            });
-            if(map._data[prop] !== undefined) {
-                canEvent.dispatch.call(map, {
-                    type: prop,
-                    target: map
-                },[map._data[prop], undefined]);
-            }
-            canBatch.stop();
-            return true;
-        }
-    },
+			map._data[prop] = defaultDefinition.type ? defaultDefinition.type(value) : define.types.observable(value);
+			instanceDefines[prop] = defaultDefinition;
+			canBatch.start();
+			canEvent.dispatch.call(map, {
+				type: "__keys",
+				target: map
+			});
+			if (map._data[prop] !== undefined) {
+				canEvent.dispatch.call(map, {
+					type: prop,
+					target: map
+				}, [ map._data[prop], undefined ]);
+			}
+			canBatch.stop();
+			return true;
+		}
+	},
     // ## getValue
 	// If `val` is an observable, calls `how` on it; otherwise
 	// returns the value of `val`.
-	getValue: function(map, name, val, how){
+	getValue: function(map, name, val, how) {
         // check if there's a serialize
-        if(how === "serialize") {
-            var constructorDefinitions = map._define.definitions;
-            var propDef = constructorDefinitions[name];
-            if(propDef && typeof propDef.serialize === "function") {
-                return propDef.serialize.call(map, val, name);
-            }
-            var defaultDefinition = map._define.defaultDefinition;
-            if(defaultDefinition && typeof defaultDefinition.serialize === "function") {
-                return defaultDefinition.serialize.call(map, val, name);
-            }
-        }
+		if (how === "serialize") {
+			var constructorDefinitions = map._define.definitions;
+			var propDef = constructorDefinitions[name];
+			if (propDef && typeof propDef.serialize === "function") {
+				return propDef.serialize.call(map, val, name);
+			}
+			var defaultDefinition = map._define.defaultDefinition;
+			if (defaultDefinition && typeof defaultDefinition.serialize === "function") {
+				return defaultDefinition.serialize.call(map, val, name);
+			}
+		}
 
-        if( hasMethod(val, how) ) {
+		if (hasMethod(val, how)) {
 			return val[how]();
-		} else {
+		}
+		else {
 			return val;
 		}
 	},
@@ -86,12 +88,12 @@ var defineHelpers = {
 	// `map` - the map or list to serialize.
 	// `how` - the method to call recursively.
 	// `where` - the target Object or Array that becomes the serialized result.
-	serialize: (function(){
+	serialize: (function() {
 
 		// A temporary mapping of map cids to the serialized result.
 		var serializeMap = null;
 
-		return function (map, how, where) {
+		return function(map, how, where) {
 			var cid = CID(map),
 				firstSerialize = false;
 
@@ -100,7 +102,7 @@ var defineHelpers = {
 			// We mark this  as the first call, and then setup the serializeMap.
 			// The serialize map is further devided into `how` because
 			// `.serialize` might call `.attr`.
-			if(!serializeMap) {
+			if (!serializeMap) {
 				firstSerialize = true;
 				serializeMap = {
 					get: {},
@@ -110,28 +112,29 @@ var defineHelpers = {
 
 			serializeMap[how][cid] = where;
 			// Go through each property.
-			map.each(function (val, name) {
+			map.each(function(val, name) {
 				// If the value is an `object`, and has an `attr` or `serialize` function.
 
-                var result,
+				var result,
 					isObservable =   hasMethod(val, how),
 					serialized = isObservable && serializeMap[how][CID(val)];
 
-				if( serialized ) {
+				if (serialized) {
 					result = serialized;
-				} else {
+				}
+				else {
 					// special attr or serializer
 					result = defineHelpers.getValue(map, name, val, how);
 				}
 				// this is probably removable
-                if(result !== undefined) {
-                    where[name] = result;
-                }
+				if (result !== undefined) {
+					where[name] = result;
+				}
 
 
 			});
 
-			if(firstSerialize) {
+			if (firstSerialize) {
 				serializeMap = null;
 			}
 			return where;

--- a/define-test.js
+++ b/define-test.js
@@ -114,15 +114,13 @@ QUnit.test("basic type", function() {
 	});
 
 
-
-
 	var t = new Typer();
 	deepEqual(Object.keys(t), [], "no keys");
 
 	var array = [];
 	t.arrayWithAddedItem = array;
 
-	deepEqual(array, ["item"], "updated array");
+	deepEqual(array, [ "item" ], "updated array");
 	QUnit.equal(t.arrayWithAddedItem, array, "leave value as array");
 
 	t.listWithAddedItem = [];
@@ -198,7 +196,7 @@ QUnit.test("type converters", function() {
 		},
 		leaveAlone: {
 			type: '*'
-		},
+		}
 	});
 
 	var obj = {};
@@ -426,13 +424,13 @@ test("Value generator can read other properties", function() {
 			value: "ABC"
 		},
 		numbers: {
-			value: [1, 2, 3]
+			value: [ 1, 2, 3 ]
 		},
 		definedLetters: {
 			value: 'DEF'
 		},
 		definedNumbers: {
-			value: [4, 5, 6]
+			value: [ 4, 5, 6 ]
 		},
 		generatedLetters: {
 			value: function() {
@@ -441,7 +439,7 @@ test("Value generator can read other properties", function() {
 		},
 		generatedNumbers: {
 			value: function() {
-				return new CanList([7, 8, 9]);
+				return new CanList([ 7, 8, 9 ]);
 			}
 		},
 
@@ -609,18 +607,18 @@ test('Can make an attr alias a compute (#1470)', 9, function() {
 	getMap.bind("value", function(ev, newVal, oldVal) {
 
 		switch (bindCallbacks) {
-			case 0:
-				equal(newVal, 2, "0 - bind called with new val");
-				equal(oldVal, 1, "0 - bind called with old val");
-				break;
-			case 1:
-				equal(newVal, 3, "1 - bind called with new val");
-				equal(oldVal, 2, "1 - bind called with old val");
-				break;
-			case 2:
-				equal(newVal, 4, "2 - bind called with new val");
-				equal(oldVal, 3, "2 - bind called with old val");
-				break;
+		case 0:
+			equal(newVal, 2, "0 - bind called with new val");
+			equal(oldVal, 1, "0 - bind called with old val");
+			break;
+		case 1:
+			equal(newVal, 3, "1 - bind called with new val");
+			equal(oldVal, 2, "1 - bind called with old val");
+			break;
+		case 2:
+			equal(newVal, 4, "2 - bind called with new val");
+			equal(oldVal, 3, "2 - bind called with old val");
+			break;
 		}
 
 
@@ -655,7 +653,7 @@ test('value and get (#1521)', function() {
 	var MyMap = define.Constructor({
 		data: {
 			value: function() {
-				return new CanList(['test']);
+				return new CanList([ 'test' ]);
 			}
 		},
 		size: {
@@ -684,12 +682,14 @@ test("One event on getters (#1585)", function() {
 			get: function(lastSetValue, resolve) {
 				if (lastSetValue) {
 					return lastSetValue;
-				} else if (this.personId) {
+				}
+				else if (this.personId) {
 					resolve(new Person({
 						name: "Jose",
 						id: 5
 					}));
-				} else {
+				}
+				else {
 					return null;
 				}
 			},
@@ -1272,7 +1272,7 @@ QUnit.test('Extensions can modify definitions', function() {
 	var MyMap = define.Constructor({
 		foo: {
 			value: 'defined',
-			extended: true,
+			extended: true
 		},
 		bar: {
 			value: 'defined'
@@ -1307,7 +1307,8 @@ QUnit.test("Properties are enumerable", function() {
 		if (i === 0) {
 			QUnit.equal(key, "foo");
 			QUnit.equal(value, "bar");
-		} else {
+		}
+		else {
 			QUnit.equal(key, "baz");
 			QUnit.equal(value, "qux");
 		}
@@ -1325,7 +1326,7 @@ QUnit.test("Doesn't override types.iterator if already on the prototype", functi
 				if (i === 0) {
 					i++;
 					return {
-						value: ["it", "worked"],
+						value: [ "it", "worked" ],
 						done: false
 					};
 				}
@@ -1438,12 +1439,12 @@ QUnit.test("shorthand getter setter (#56)", function() {
 });
 
 
-QUnit.test("set and value work together (#87)", function(){
+QUnit.test("set and value work together (#87)", function() {
 
 	var Type = define.Constructor({
 		prop: {
 			value: 2,
-			set: function(num){
+			set: function(num) {
 				return num * num;
 			}
 		}
@@ -1455,19 +1456,19 @@ QUnit.test("set and value work together (#87)", function(){
 
 });
 
-QUnit.test("async setter is provided", 5, function(){
+QUnit.test("async setter is provided", 5, function() {
 	var RESOLVE;
 
 	var Type = define.Constructor({
 		prop: {
 			value: 2,
-			set: function(num, resolve){
-				resolve( num * num );
+			set: function(num, resolve) {
+				resolve(num * num);
 			}
 		},
 		prop2: {
 			value: 3,
-			set: function(num, resolve){
+			set: function(num, resolve) {
 				RESOLVE = resolve;
 			}
 		}
@@ -1480,7 +1481,7 @@ QUnit.test("async setter is provided", 5, function(){
 
 	QUnit.equal(instance.prop2, undefined, "used async setter");
 
-	instance.on("prop2", function(ev, newVal, oldVal){
+	instance.on("prop2", function(ev, newVal, oldVal) {
 		QUnit.equal(newVal, 9, "updated");
 		QUnit.equal(oldVal, undefined, "updated");
 	});
@@ -1490,12 +1491,12 @@ QUnit.test("async setter is provided", 5, function(){
 
 });
 
-QUnit.test('setter with default value causes an infinite loop (#142)', function(){
+QUnit.test('setter with default value causes an infinite loop (#142)', function() {
 	var A = define.Constructor({
 		val: {
 			value: 'hello',
-			set: function(val){
-				if(this.val) {}
+			set: function(val) {
+				if (this.val) {}
 				return val;
 			}
 		}

--- a/document.js
+++ b/document.js
@@ -4,15 +4,15 @@ var readmeGenerate = require("bit-docs-generate-readme");
 
 bitDocs(
     path.join(__dirname, "package.json"),
-    {
-        debug: true,
-        readme: {
-            apis: "./docs/apis.json"
-        },
-        generators: [readmeGenerate]
-    }).catch(function(e){
+	{
+		debug: true,
+		readme: {
+			apis: "./docs/apis.json"
+		},
+		generators: [ readmeGenerate ]
+	}).catch(function(e) {
 
-        setTimeout(function(){
-            throw e;
-        }, 1);
-    });
+		setTimeout(function() {
+			throw e;
+		}, 1);
+	});

--- a/list/list-test.js
+++ b/list/list-test.js
@@ -32,6 +32,15 @@ QUnit.test("creating an instance", function() {
 	list.push("d");
 });
 
+QUnit.test("List is iterable (canjs/can-stache#68)", function(assert) {
+	var list = new DefineList([ "a", "b", "c" ]);
+	assert.ok(isIterable(list));
+
+	// let index = 0;
+	// for (var item of list) {
+	// 	assert.equal(item, list[index++]);
+	// }
+});
 test('list attr changes length', function() {
 	var l = new DefineList([
 		0,

--- a/list/list-test.js
+++ b/list/list-test.js
@@ -4,6 +4,7 @@ var DefineList = require("can-define/list/list");
 var DefineMap = require("can-define/map/map");
 var Observation = require("can-observation");
 var define = require("can-define");
+var isIterable = require("can-util/js/is-iterable/is-iterable");
 
 var assign = require("can-util/js/assign/assign");
 var CID = require("can-cid");
@@ -18,6 +19,7 @@ QUnit.test("List is an event emitter", function(assert) {
 	var List = Base.extend({});
 	assert.ok(List.on, 'List has event methods.');
 });
+
 
 QUnit.test("creating an instance", function() {
 	var list = new DefineList([ "a", "b", "c" ]);
@@ -400,9 +402,11 @@ test('list.sort a list of objects', function() {
 	objList.sort(function(a, b) {
 		if (a.name < b.name) {
 			return -1;
-		} else if (a.name > b.name) {
+		}
+		else if (a.name > b.name) {
 			return 1;
-		} else {
+		}
+		else {
 			return 0;
 		}
 	});
@@ -453,9 +457,11 @@ test('list.sort a list of DefineMaps', function() {
 	accounts.sort(function(a, b) {
 		if (a.name < b.name) {
 			return -1;
-		} else if (a.name > b.name) {
+		}
+		else if (a.name > b.name) {
 			return 1;
-		} else {
+		}
+		else {
 			return 0;
 		}
 	});
@@ -466,9 +472,11 @@ test('list.sort a list of DefineMaps', function() {
 	accounts.sort(function(a, b) {
 		if (a.slug < b.slug) {
 			return 1;
-		} else if (a.slug > b.slug) {
+		}
+		else if (a.slug > b.slug) {
 			return -1;
-		} else {
+		}
+		else {
 			return 0;
 		}
 	});

--- a/list/list.js
+++ b/list/list.js
@@ -46,7 +46,8 @@ var DefineList = Construct.extend("DefineList",
 				if (itemsDefinition) {
 					if (itemsDefinition.Type) {
 						this.prototype.__type = make.set.Type("*", itemsDefinition.Type, identity);
-					} else if (itemsDefinition.type) {
+					}
+					else if (itemsDefinition.type) {
 						this.prototype.__type = make.set.type("*", itemsDefinition.type, identity);
 					}
 				}
@@ -93,16 +94,19 @@ var DefineList = Construct.extend("DefineList",
 					}
 					canEvent.dispatch.call(this, how, [ newVal, index ]);
 					canEvent.dispatch.call(this, 'length', [ this._length ]);
-				} else if (how === 'remove') {
+				}
+				else if (how === 'remove') {
 					if (itemsDefinition && typeof itemsDefinition.removed === 'function') {
 						Observation.ignore(itemsDefinition.removed).call(this, oldVal, index);
 					}
 					canEvent.dispatch.call(this, how, [ oldVal, index ]);
 					canEvent.dispatch.call(this, 'length', [ this._length ]);
-				} else {
+				}
+				else {
 					canEvent.dispatch.call(this, how, [ newVal, index ]);
 				}
-			} else {
+			}
+			else {
 				canEvent.dispatch.call(this, {
 					type: "" + attr,
 					target: this
@@ -169,7 +173,8 @@ var DefineList = Construct.extend("DefineList",
 			if (arguments.length) {
 				Observation.add(this, "" + index);
 				return this[index];
-			} else {
+			}
+			else {
 				return defineHelpers.serialize(this, 'get', []);
 			}
 		},
@@ -251,7 +256,8 @@ var DefineList = Construct.extend("DefineList",
 						return newArr;
 					}
 					this.splice(prop, 1, value);
-				} else {
+				}
+				else {
 					var defined = defineHelpers.defineExpando(this, prop, value);
 					if (!defined) {
 						this[prop] = value;
@@ -264,10 +270,12 @@ var DefineList = Construct.extend("DefineList",
 				if (isArray(prop)) {
 					if (value) {
 						this.replace(prop);
-					} else {
+					}
+					else {
 						this.splice.apply(this, [ 0, prop.length ].concat(prop));
 					}
-				} else {
+				}
+				else {
 					each(prop, function(value, prop) {
 						this.set(prop, value);
 					}, this);
@@ -804,7 +812,8 @@ assign(DefineList.prototype, {
 				each(arr, function(innerArg) {
 					args.push(this.__type(innerArg));
 				}, this);
-			} else {
+			}
+			else {
 				// If it is a Map, Object, or some primitive
 				// just pass arg to this.__type
 				args.push(this.__type(arg));
@@ -1104,18 +1113,22 @@ DefineList.prototype.attr = function(prop, value) {
 	canLog.warn("DefineMap::attr shouldn't be called");
 	if (arguments.length === 0) {
 		return this.get();
-	} else if (prop && typeof prop === "object") {
+	}
+	else if (prop && typeof prop === "object") {
 		return this.set.apply(this, arguments);
-	} else if (arguments.length === 1) {
+	}
+	else if (arguments.length === 1) {
 		return this.get(prop);
-	} else {
+	}
+	else {
 		return this.set(prop, value);
 	}
 };
 DefineList.prototype.item = function(index, value) {
 	if (arguments.length === 1) {
 		return this.get(index);
-	} else {
+	}
+	else {
 		return this.set(index, value);
 	}
 };

--- a/list/list.js
+++ b/list/list.js
@@ -414,6 +414,17 @@ var DefineList = Construct.extend("DefineList",
 		}
 	});
 
+// Places Symbol.iterator or @@iterator on the prototype
+// so that this can be iterated with for/of and can-util/js/each/each
+Object.defineProperty(DefineList.prototype, types.iterator, {
+	configurable: true,
+	enumerable: false,
+	writable: true,
+	value: function() {
+		return new define.Iterator(this);
+	}
+});
+
 // Converts to an `array` of arguments.
 var getArgs = function(args) {
 	return args[0] && Array.isArray(args[0]) ?

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -5,123 +5,125 @@ var Observation = require("can-observation");
 var canTypes = require("can-types");
 var each = require("can-util/js/each/each");
 var compute = require("can-compute");
+var isIterable = require("can-util/js/is-iterable/is-iterable");
 var sealWorks = (function() {
 	try {
 		var o = {};
 		Object.seal(o);
 		o.prop = true;
 		return false;
-	} catch(e) {
+	}
+	catch (e) {
 		return true;
 	}
 })();
 
 QUnit.module("can-define/map/map");
 
-QUnit.test("Map is an event emitter", function (assert) {
+QUnit.test("Map is an event emitter", function(assert) {
 	var Base = DefineMap.extend({});
 	assert.ok(Base.on, 'Base has event methods.');
 	var Map = Base.extend({});
 	assert.ok(Map.on, 'Map has event methods.');
 });
 
-QUnit.test("creating an instance", function(){
-    var map = new DefineMap({prop: "foo"});
-    map.on("prop", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "BAR");
-        QUnit.equal(oldVal, "foo");
-    });
+QUnit.test("creating an instance", function() {
+	var map = new DefineMap({ prop: "foo" });
+	map.on("prop", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "BAR");
+		QUnit.equal(oldVal, "foo");
+	});
 
-    map.prop = "BAR";
+	map.prop = "BAR";
 });
 
-QUnit.test("creating an instance with nested prop", function(){
+QUnit.test("creating an instance with nested prop", function() {
 
-    var map = new DefineMap({name: {first: "Justin"}});
+	var map = new DefineMap({ name: { first: "Justin" } });
 
-    map.name.on("first", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "David");
-        QUnit.equal(oldVal, "Justin");
-    });
+	map.name.on("first", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "David");
+		QUnit.equal(oldVal, "Justin");
+	});
 
-    map.name.first = "David";
+	map.name.first = "David";
 });
 
 
-QUnit.test("extending", function(){
-    var MyMap = DefineMap.extend({
-        prop: {}
-    });
+QUnit.test("extending", function() {
+	var MyMap = DefineMap.extend({
+		prop: {}
+	});
 
-    var map = new MyMap();
-    map.on("prop", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "BAR");
-        QUnit.equal(oldVal, undefined);
-    });
+	var map = new MyMap();
+	map.on("prop", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "BAR");
+		QUnit.equal(oldVal, undefined);
+	});
 
-    map.prop = "BAR";
+	map.prop = "BAR";
 });
 
-QUnit.test("loop only through defined serializable props", function(){
-    var MyMap = DefineMap.extend({
-        propA: {},
-        propB: {serialize: false},
-        propC: {
-            get: function(){
-                return this.propA;
-            }
-        }
-    });
-    var inst = new MyMap({propA: 1, propB: 2});
-    QUnit.deepEqual(Object.keys(inst.get()), ["propA"]);
-
-});
-
-QUnit.test("get and set can setup expandos", function(){
-    var map = new DefineMap();
-    var oi = new Observation(function(){
-        return map.get("foo");
-    },null,{
-        updater: function(newVal){
-            QUnit.equal(newVal, "bar", "updated to bar");
-        }
-    });
-    oi.start();
-
-    map.set("foo","bar");
+QUnit.test("loop only through defined serializable props", function() {
+	var MyMap = DefineMap.extend({
+		propA: {},
+		propB: { serialize: false },
+		propC: {
+			get: function() {
+				return this.propA;
+			}
+		}
+	});
+	var inst = new MyMap({ propA: 1, propB: 2 });
+	QUnit.deepEqual(Object.keys(inst.get()), [ "propA" ]);
 
 });
 
-QUnit.test("default settings", function(){
-    var MyMap = DefineMap.extend({
-        "*": "string",
-        foo: {}
-    });
+QUnit.test("get and set can setup expandos", function() {
+	var map = new DefineMap();
+	var oi = new Observation(function() {
+		return map.get("foo");
+	}, null, {
+		updater: function(newVal) {
+			QUnit.equal(newVal, "bar", "updated to bar");
+		}
+	});
+	oi.start();
 
-    var m = new MyMap();
-    m.set("foo",123);
-    QUnit.ok(m.get("foo") === "123");
+	map.set("foo", "bar");
 
 });
 
-QUnit.test("default settings on unsealed", function(){
-    var MyMap = DefineMap.extend({
-        seal: false
-    },{
-        "*": "string"
-    });
+QUnit.test("default settings", function() {
+	var MyMap = DefineMap.extend({
+		"*": "string",
+		foo: {}
+	});
 
-    var m = new MyMap();
-    m.set("foo",123);
-    QUnit.ok(m.get("foo") === "123");
+	var m = new MyMap();
+	m.set("foo", 123);
+	QUnit.ok(m.get("foo") === "123");
+
+});
+
+QUnit.test("default settings on unsealed", function() {
+	var MyMap = DefineMap.extend({
+		seal: false
+	}, {
+		"*": "string"
+	});
+
+	var m = new MyMap();
+	m.set("foo", 123);
+	QUnit.ok(m.get("foo") === "123");
 
 });
 
 if (!System.isEnv('production')) {
-	QUnit.test("extends sealed objects (#48)", function(){
+	QUnit.test("extends sealed objects (#48)", function() {
 		var Map1 = DefineMap.extend({ seal: true }, {
 			name: {
-				get: function(curVal){
+				get: function(curVal) {
 					return "computed " + curVal;
 				}
 			}
@@ -134,10 +136,12 @@ if (!System.isEnv('production')) {
 			map1.foo = "bar";
 			if (map1.foo) {
 				QUnit.ok(false, "map1 not sealed");
-			} else {
+			}
+			else {
 				QUnit.ok(true, "map1 sealed - silent failure");
 			}
-		} catch(ex) {
+		}
+		catch (ex) {
 			QUnit.ok(true, "map1 sealed");
 		}
 		QUnit.equal(map1.name, "computed Justin", "map1.name property is computed");
@@ -147,10 +151,12 @@ if (!System.isEnv('production')) {
 			map2.foo = "bar";
 			if (map2.foo) {
 				QUnit.ok(true, "map2 not sealed");
-			} else {
+			}
+			else {
 				QUnit.ok(false, "map2 sealed");
 			}
-		} catch (ex) {
+		}
+		catch (ex) {
 			QUnit.ok(false, "map2 sealed");
 		}
 		QUnit.equal(map2.name, "computed Brian", "map2.name property is computed");
@@ -160,291 +166,294 @@ if (!System.isEnv('production')) {
 			map3.foo = "bar";
 			if (map3.foo) {
 				QUnit.ok(false, "map3 not sealed");
-			} else {
+			}
+			else {
 				QUnit.ok(true, "map3 sealed");
 			}
-		} catch (ex) {
+		}
+		catch (ex) {
 			QUnit.ok(true, "map3 sealed");
 		}
 		QUnit.equal(map3.name, "computed Curtis", "map3.name property is computed");
 	});
 }
 
-QUnit.test("get with dynamically added properties", function(){
-    var map = new DefineMap();
-    map.set("a",1);
-    map.set("b",2);
-    QUnit.deepEqual(map.get(), {a: 1, b: 2});
+QUnit.test("get with dynamically added properties", function() {
+	var map = new DefineMap();
+	map.set("a", 1);
+	map.set("b", 2);
+	QUnit.deepEqual(map.get(), { a: 1, b: 2 });
 });
 
 
-QUnit.test("set multiple props", function(){
-    var map = new DefineMap();
-    map.set({a: 0, b: 2});
+QUnit.test("set multiple props", function() {
+	var map = new DefineMap();
+	map.set({ a: 0, b: 2 });
 
-    QUnit.deepEqual(map.get(), {a: 0, b: 2});
+	QUnit.deepEqual(map.get(), { a: 0, b: 2 });
 
-    map.set({a: 2}, true);
+	map.set({ a: 2 }, true);
 
-    QUnit.deepEqual(map.get(), {a: 2});
+	QUnit.deepEqual(map.get(), { a: 2 });
 
-    map.set({foo: {bar: "VALUE"}});
+	map.set({ foo: { bar: "VALUE" } });
 
-    QUnit.deepEqual(map.get(), {foo: {bar: "VALUE"}, a: 2});
+	QUnit.deepEqual(map.get(), { foo: { bar: "VALUE" }, a: 2 });
 });
 
-QUnit.test("serialize responds to added props", function(){
-    var map = new DefineMap();
-    var oi = new Observation(function(){
-        return map.serialize();
-    },null,{
-        updater: function(newVal){
-            QUnit.deepEqual(newVal, {a: 1, b: 2}, "updated right");
-        }
-    });
-    oi.start();
+QUnit.test("serialize responds to added props", function() {
+	var map = new DefineMap();
+	var oi = new Observation(function() {
+		return map.serialize();
+	}, null, {
+		updater: function(newVal) {
+			QUnit.deepEqual(newVal, { a: 1, b: 2 }, "updated right");
+		}
+	});
+	oi.start();
 
-    map.set({a: 1, b: 2});
+	map.set({ a: 1, b: 2 });
 });
 
-QUnit.test("initialize an undefined property", function(){
-    var MyMap = DefineMap.extend({seal: false},{});
-    var instance = new MyMap({foo: "bar"});
+QUnit.test("initialize an undefined property", function() {
+	var MyMap = DefineMap.extend({ seal: false }, {});
+	var instance = new MyMap({ foo: "bar" });
 
-    equal(instance.foo, "bar");
+	equal(instance.foo, "bar");
 });
 
-QUnit.test("set an already initialized null property", function(){
-  var map = new DefineMap({ foo: null });
-  map.set({ foo: null });
+QUnit.test("set an already initialized null property", function() {
+	var map = new DefineMap({ foo: null });
+	map.set({ foo: null });
 
-  equal(map.foo, null);
+	equal(map.foo, null);
 });
 
-QUnit.test("creating a new key doesn't cause two changes", 1, function(){
-    var map = new DefineMap();
-    var oi = new Observation(function(){
-        return map.serialize();
-    },null,{
-        updater: function(newVal){
-            QUnit.deepEqual(newVal, {a: 1}, "updated right");
-        }
-    });
-    oi.start();
+QUnit.test("creating a new key doesn't cause two changes", 1, function() {
+	var map = new DefineMap();
+	var oi = new Observation(function() {
+		return map.serialize();
+	}, null, {
+		updater: function(newVal) {
+			QUnit.deepEqual(newVal, { a: 1 }, "updated right");
+		}
+	});
+	oi.start();
 
-    map.set("a", 1);
+	map.set("a", 1);
 });
 
-QUnit.test("setting nested object", function(){
-    var m = new DefineMap({});
+QUnit.test("setting nested object", function() {
+	var m = new DefineMap({});
 
-    m.set({foo: {}});
-    m.set({foo: {}});
-    QUnit.deepEqual(m.get(), {foo: {}});
+	m.set({ foo: {} });
+	m.set({ foo: {} });
+	QUnit.deepEqual(m.get(), { foo: {} });
 });
 
-QUnit.test("passing a DefineMap to DefineMap (#33)", function(){
-    var MyMap = DefineMap.extend({foo: "observable"});
-    var m = new MyMap({foo: {}, bar: {}});
+QUnit.test("passing a DefineMap to DefineMap (#33)", function() {
+	var MyMap = DefineMap.extend({ foo: "observable" });
+	var m = new MyMap({ foo: {}, bar: {} });
 
-    var m2 = new MyMap(m);
-    QUnit.deepEqual(m.get(), m2.get());
-    QUnit.ok(m.foo === m2.foo, "defined props the same");
-    QUnit.ok(m.bar === m2.bar, "expando props the same");
-
-});
-
-QUnit.test("serialize: function works (#38)", function(){
-    var Something = DefineMap.extend({});
-
-    var MyMap = DefineMap.extend({
-        somethingRef: {
-            type: function(val){
-                return new Something({id: val});
-            },
-            serialize: function(val){
-                return val.id;
-            }
-        },
-        somethingElseRef: {
-            type: function(val){
-                return new Something({id: val});
-            },
-            serialize: false
-        }
-    });
-
-    var myMap = new MyMap({somethingRef: 2, somethingElseRef: 3});
-
-    QUnit.ok(myMap.somethingRef instanceof Something);
-    QUnit.deepEqual( myMap.serialize(), {somethingRef: 2}, "serialize: function and serialize: false works");
-
-
-    var MyMap2 = DefineMap.extend({
-        "*": {
-            serialize: function(value){
-                return "" + value;
-            }
-        }
-    });
-
-    var myMap2 = new MyMap2({foo: 1, bar: 2});
-    QUnit.deepEqual( myMap2.serialize(), {foo: "1", bar: "2"}, "serialize: function on default works");
+	var m2 = new MyMap(m);
+	QUnit.deepEqual(m.get(), m2.get());
+	QUnit.ok(m.foo === m2.foo, "defined props the same");
+	QUnit.ok(m.bar === m2.bar, "expando props the same");
 
 });
 
-QUnit.test("isMapLike", function(){
-    var map = new DefineMap({});
-    ok(canTypes.isMapLike(map), "is map like");
+QUnit.test("serialize: function works (#38)", function() {
+	var Something = DefineMap.extend({});
+
+	var MyMap = DefineMap.extend({
+		somethingRef: {
+			type: function(val) {
+				return new Something({ id: val });
+			},
+			serialize: function(val) {
+				return val.id;
+			}
+		},
+		somethingElseRef: {
+			type: function(val) {
+				return new Something({ id: val });
+			},
+			serialize: false
+		}
+	});
+
+	var myMap = new MyMap({ somethingRef: 2, somethingElseRef: 3 });
+
+	QUnit.ok(myMap.somethingRef instanceof Something);
+	QUnit.deepEqual(myMap.serialize(), { somethingRef: 2 }, "serialize: function and serialize: false works");
+
+
+	var MyMap2 = DefineMap.extend({
+		"*": {
+			serialize: function(value) {
+				return "" + value;
+			}
+		}
+	});
+
+	var myMap2 = new MyMap2({ foo: 1, bar: 2 });
+	QUnit.deepEqual(myMap2.serialize(), { foo: "1", bar: "2" }, "serialize: function on default works");
+
 });
 
-QUnit.test("get will not create properties", function(){
-    var method = function(){};
-    var MyMap = DefineMap.extend({
-        method: method
-    });
-    var m = new MyMap();
-    m.get("foo");
-
-    QUnit.equal(m.get("method"), method);
+QUnit.test("isMapLike", function() {
+	var map = new DefineMap({});
+	ok(canTypes.isMapLike(map), "is map like");
 });
 
-QUnit.test("Properties are enumerable", function(){
-  QUnit.expect(4);
+QUnit.test("get will not create properties", function() {
+	var method = function() {};
+	var MyMap = DefineMap.extend({
+		method: method
+	});
+	var m = new MyMap();
+	m.get("foo");
 
-  var VM = DefineMap.extend({
-    foo: "string"
-  });
-  var vm = new VM({ foo: "bar", baz: "qux" });
-
-  var i = 0;
-  each(vm, function(value, key){
-    if(i === 0) {
-      QUnit.equal(key, "foo");
-      QUnit.equal(value, "bar");
-    } else {
-      QUnit.equal(key, "baz");
-      QUnit.equal(value, "qux");
-    }
-    i++;
-  });
+	QUnit.equal(m.get("method"), method);
 });
 
-QUnit.test("Getters are not enumerable", function(){
-  QUnit.expect(2);
+QUnit.test("Properties are enumerable", function() {
+	QUnit.expect(4);
 
-  var MyMap = DefineMap.extend({
-    foo: "string",
-    baz: {
-      get: function(){
-        return this.foo;
-      }
-    }
-  });
+	var VM = DefineMap.extend({
+		foo: "string"
+	});
+	var vm = new VM({ foo: "bar", baz: "qux" });
 
-  var map = new MyMap({ foo: "bar" });
-
-  each(map, function(value, key){
-    QUnit.equal(key, "foo");
-    QUnit.equal(value, "bar");
-  });
+	var i = 0;
+	each(vm, function(value, key) {
+		if (i === 0) {
+			QUnit.equal(key, "foo");
+			QUnit.equal(value, "bar");
+		}
+		else {
+			QUnit.equal(key, "baz");
+			QUnit.equal(value, "qux");
+		}
+		i++;
+	});
 });
 
-QUnit.test("extending DefineMap constructor functions (#18)", function(){
-    var AType = DefineMap.extend("AType", { aProp: {}, aMethod: function(){} });
+QUnit.test("Getters are not enumerable", function() {
+	QUnit.expect(2);
 
-    var BType = AType.extend("BType", { bProp: {}, bMethod: function(){} });
+	var MyMap = DefineMap.extend({
+		foo: "string",
+		baz: {
+			get: function() {
+				return this.foo;
+			}
+		}
+	});
 
-    var CType = BType.extend("CType", { cProp: {}, cMethod: function(){} });
+	var map = new MyMap({ foo: "bar" });
 
-    var map = new CType();
-
-    map.on("aProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "PROP");
-        QUnit.equal(oldVal, undefined);
-    });
-    map.on("bProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "FOO");
-        QUnit.equal(oldVal, undefined);
-    });
-    map.on("cProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "BAR");
-        QUnit.equal(oldVal, undefined);
-    });
-
-    map.aProp = "PROP";
-    map.bProp = 'FOO';
-    map.cProp = 'BAR';
-    QUnit.ok(map.aMethod);
-    QUnit.ok(map.bMethod);
-    QUnit.ok(map.cMethod);
+	each(map, function(value, key) {
+		QUnit.equal(key, "foo");
+		QUnit.equal(value, "bar");
+	});
 });
 
-QUnit.test("extending DefineMap constructor functions more than once (#18)", function(){
-    var AType = DefineMap.extend("AType", { aProp: {}, aMethod: function(){} });
+QUnit.test("extending DefineMap constructor functions (#18)", function() {
+	var AType = DefineMap.extend("AType", { aProp: {}, aMethod: function() {} });
 
-    var BType = AType.extend("BType", { bProp: {}, bMethod: function(){} });
+	var BType = AType.extend("BType", { bProp: {}, bMethod: function() {} });
 
-    var CType = AType.extend("CType", { cProp: {}, cMethod: function(){} });
+	var CType = BType.extend("CType", { cProp: {}, cMethod: function() {} });
 
-    var map1 = new BType();
-    var map2 = new CType();
+	var map = new CType();
 
-    map1.on("aProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "PROP", "aProp newVal on map1");
-        QUnit.equal(oldVal, undefined);
-    });
-    map1.on("bProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "FOO", "bProp newVal on map1");
-        QUnit.equal(oldVal, undefined);
-    });
+	map.on("aProp", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "PROP");
+		QUnit.equal(oldVal, undefined);
+	});
+	map.on("bProp", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "FOO");
+		QUnit.equal(oldVal, undefined);
+	});
+	map.on("cProp", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "BAR");
+		QUnit.equal(oldVal, undefined);
+	});
 
-    map2.on("aProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "PROP", "aProp newVal on map2");
-        QUnit.equal(oldVal, undefined);
-    });
-    map2.on("cProp", function(ev, newVal, oldVal){
-        QUnit.equal(newVal, "BAR", "cProp newVal on map2");
-        QUnit.equal(oldVal, undefined);
-    });
-
-    map1.aProp = "PROP";
-    map1.bProp = 'FOO';
-    map2.aProp = "PROP";
-    map2.cProp = 'BAR';
-    QUnit.ok(map1.aMethod, "map1 aMethod");
-    QUnit.ok(map1.bMethod);
-    QUnit.ok(map2.aMethod);
-    QUnit.ok(map2.cMethod, "map2 cMethod");
+	map.aProp = "PROP";
+	map.bProp = 'FOO';
+	map.cProp = 'BAR';
+	QUnit.ok(map.aMethod);
+	QUnit.ok(map.bMethod);
+	QUnit.ok(map.cMethod);
 });
 
-QUnit.test("extending DefineMap constructor functions - value (#18)", function(){
-    var AType = DefineMap.extend("AType", { aProp: {value: 1} });
+QUnit.test("extending DefineMap constructor functions more than once (#18)", function() {
+	var AType = DefineMap.extend("AType", { aProp: {}, aMethod: function() {} });
 
-    var BType = AType.extend("BType", { });
+	var BType = AType.extend("BType", { bProp: {}, bMethod: function() {} });
 
-    var CType = BType.extend("CType",{ });
+	var CType = AType.extend("CType", { cProp: {}, cMethod: function() {} });
 
-    var c = new CType();
-    QUnit.equal( c.aProp , 1 ,"got initial value" );
+	var map1 = new BType();
+	var map2 = new CType();
+
+	map1.on("aProp", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "PROP", "aProp newVal on map1");
+		QUnit.equal(oldVal, undefined);
+	});
+	map1.on("bProp", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "FOO", "bProp newVal on map1");
+		QUnit.equal(oldVal, undefined);
+	});
+
+	map2.on("aProp", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "PROP", "aProp newVal on map2");
+		QUnit.equal(oldVal, undefined);
+	});
+	map2.on("cProp", function(ev, newVal, oldVal) {
+		QUnit.equal(newVal, "BAR", "cProp newVal on map2");
+		QUnit.equal(oldVal, undefined);
+	});
+
+	map1.aProp = "PROP";
+	map1.bProp = 'FOO';
+	map2.aProp = "PROP";
+	map2.cProp = 'BAR';
+	QUnit.ok(map1.aMethod, "map1 aMethod");
+	QUnit.ok(map1.bMethod);
+	QUnit.ok(map2.aMethod);
+	QUnit.ok(map2.cMethod, "map2 cMethod");
 });
 
-QUnit.test("shorthand getter setter (#56)", function(){
+QUnit.test("extending DefineMap constructor functions - value (#18)", function() {
+	var AType = DefineMap.extend("AType", { aProp: { value: 1 } });
 
-    var Person = DefineMap.extend({
+	var BType = AType.extend("BType", { });
+
+	var CType = BType.extend("CType", { });
+
+	var c = new CType();
+	QUnit.equal(c.aProp, 1, "got initial value");
+});
+
+QUnit.test("shorthand getter setter (#56)", function() {
+
+	var Person = DefineMap.extend({
 		first: "*",
 		last: "*",
 		get fullName() {
 			return this.first + " " + this.last;
 		},
-		set fullName(newVal){
+		set fullName(newVal) {
 			var parts = newVal.split(" ");
 			this.first = parts[0];
 			this.last = parts[1];
 		}
 	});
 
-	var p = new Person({first: "Mohamed", last: "Cherif"});
+	var p = new Person({ first: "Mohamed", last: "Cherif" });
 
 	p.on("fullName", function(ev, newVal, oldVal) {
 		QUnit.equal(oldVal, "Mohamed Cherif");
@@ -463,106 +472,107 @@ QUnit.test('compute props can be set to null or undefined (#2372)', function() {
 		}
 	});
 
-	var vmNull = new VM({computeProp: null});
+	var vmNull = new VM({ computeProp: null });
 	QUnit.equal(vmNull.get('computeProp'), null, 'computeProp is null, no error thrown');
-	var vmUndef = new VM({computeProp: undefined});
+	var vmUndef = new VM({ computeProp: undefined });
 	QUnit.equal(vmUndef.get('computeProp'), undefined, 'computeProp is undefined, no error thrown');
 });
 
-QUnit.test("Inheriting DefineMap .set doesn't work if prop is on base map (#74)", function(){
-    var Base = DefineMap.extend({
-        baseProp: "string"
-    });
+QUnit.test("Inheriting DefineMap .set doesn't work if prop is on base map (#74)", function() {
+	var Base = DefineMap.extend({
+		baseProp: "string"
+	});
 
-    var Inheriting = Base.extend();
+	var Inheriting = Base.extend();
 
-    var inherting = new Inheriting();
+	var inherting = new Inheriting();
 
-    inherting.set("baseProp", "value");
+	inherting.set("baseProp", "value");
 
 
-    QUnit.equal(inherting.baseProp,"value", "set prop");
+	QUnit.equal(inherting.baseProp, "value", "set prop");
 });
 
-if(sealWorks && System.env.indexOf('production') < 0) {
-	QUnit.test("setting not defined property", function(){
-	    var MyMap = DefineMap.extend({
-	        prop: {}
-	    });
-	    var mymap = new MyMap();
+if (sealWorks && System.env.indexOf('production') < 0) {
+	QUnit.test("setting not defined property", function() {
+		var MyMap = DefineMap.extend({
+			prop: {}
+		});
+		var mymap = new MyMap();
 
-	    try {
-	        mymap.notdefined = "value";
-	        ok(false, "no error");
-	    } catch(e) {
-	        ok(true, "error thrown");
-	    }
+		try {
+			mymap.notdefined = "value";
+			ok(false, "no error");
+		}
+		catch (e) {
+			ok(true, "error thrown");
+		}
 	});
 }
 
-QUnit.test(".extend errors when re-defining a property (#117)", function(){
+QUnit.test(".extend errors when re-defining a property (#117)", function() {
 
 	var A = DefineMap.extend("A", {
-	    foo: {
-	        type: "string",
-	        value: "blah"
-	    }
+		foo: {
+			type: "string",
+			value: "blah"
+		}
 	});
 
 
 	A.extend("B", {
-	    foo: {
-	        type: "string",
-	        value: "flub"
-	    }
+		foo: {
+			type: "string",
+			value: "flub"
+		}
 	});
 
 	var C = DefineMap.extend("C", {
-	    foo: {
-	        get: function() {
-	            return "blah";
-	        }
-	    }
+		foo: {
+			get: function() {
+				return "blah";
+			}
+		}
 	});
 
 
 	C.extend("D", {
-	    foo: {
-	        get: function() {
-	            return "flub";
-	        }
-	    }
+		foo: {
+			get: function() {
+				return "flub";
+			}
+		}
 	});
 	QUnit.ok(true, "extended without errors");
 });
 
-QUnit.test(".value functions should not be observable", function(){
+QUnit.test(".value functions should not be observable", function() {
 	var outer = new DefineMap({
 		bam: "baz"
 	});
-	
+
 	var ItemsVM = DefineMap.extend({
 		item: {
-			value: function(){
-				(function(){})(this.zed, outer.bam);
+			value: function() {
+				(function() {})(this.zed, outer.bam);
 				return new DefineMap({ foo: "bar" });
 			}
 		},
 		zed: "string"
 	});
-	
+
 	var items = new ItemsVM();
-	
+
 	var count = 0;
-	var itemsList = compute(function(){
+	var itemsList = compute(function() {
 		count++;
 		return items.item;
 	});
-	
+
 	itemsList.on('change', function() {});
-	
+
 	items.item.foo = "changed";
 	items.zed = "changed";
-	
+
 	equal(count, 1);
 });

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -37,6 +37,15 @@ QUnit.test("creating an instance", function() {
 	map.prop = "BAR";
 });
 
+QUnit.test("Map is iterable (canjs/can-stache#68)", function(assert) {
+	var map = new DefineMap({ foo: "bar", bam: "baz" });
+	assert.ok(isIterable(map));
+
+	// for (var item of map) {
+	// 	assert.equal(item[1], map[item[0]]);
+	// }
+});
+
 QUnit.test("creating an instance with nested prop", function() {
 
 	var map = new DefineMap({ name: { first: "Justin" } });

--- a/map/map.js
+++ b/map/map.js
@@ -261,6 +261,17 @@ var DefineMap = Construct.extend("DefineMap", {
 	}
 });
 
+// Places Symbol.iterator or @@iterator on the prototype
+// so that this can be iterated with for/of and can-util/js/each/each
+Object.defineProperty(DefineMap.prototype, types.iterator, {
+	configurable: true,
+	enumerable: false,
+	writable: true,
+	value: function() {
+		return new define.Iterator(this);
+	}
+});
+
 // Add necessary event methods to this object.
 for (var prop in define.eventsProto) {
 	DefineMap[prop] = define.eventsProto[prop];

--- a/map/map.js
+++ b/map/map.js
@@ -10,106 +10,106 @@ var canBatch = require("can-event/batch/batch");
 var ns = require("can-namespace");
 var canLog = require("can-util/js/log/log");
 
-var readWithoutObserve = Observation.ignore(function(map, prop){
-    return map[prop];
+var readWithoutObserve = Observation.ignore(function(map, prop) {
+	return map[prop];
 });
 
 var eachDefinition = function(map, cb, thisarg, definitions, observe) {
 
-    for(var prop in definitions) {
-        var definition = definitions[prop];
-        if(typeof definition !== "object" || ("serialize" in definition ? !!definition.serialize : !definition.get)) {
+	for (var prop in definitions) {
+		var definition = definitions[prop];
+		if (typeof definition !== "object" || ("serialize" in definition ? !!definition.serialize : !definition.get)) {
 
-            var item = observe === false ? readWithoutObserve(map, prop) : map[prop];
+			var item = observe === false ? readWithoutObserve(map, prop) : map[prop];
 
-            if (cb.call(thisarg || item, item, prop, map) === false) {
-                return false;
-            }
-        }
-    }
+			if (cb.call(thisarg || item, item, prop, map) === false) {
+				return false;
+			}
+		}
+	}
 };
 
 var setProps = function(props, remove) {
-    props = assign({}, props);
-    var prop,
-        self = this,
-        newVal;
+	props = assign({}, props);
+	var prop,
+		self = this,
+		newVal;
 
     // Batch all of the change events until we are done.
-    canBatch.start();
+	canBatch.start();
     // Merge current properties with the new ones.
-    this.each(function(curVal, prop) {
+	this.each(function(curVal, prop) {
         // You can not have a _cid property; abort.
-        if (prop === "_cid") {
-            return;
-        }
-        newVal = props[prop];
+		if (prop === "_cid") {
+			return;
+		}
+		newVal = props[prop];
 
         // If we are merging, remove the property if it has no value.
-        if (newVal === undefined) {
-            if (remove) {
-                self[prop] = undefined;
-            }
-            return;
-        }
-        if( typeof curVal !== "object" || curVal === null ) {
-            self.set(prop, newVal);
-        }
-        else if( ("replace" in curVal) && isArray(newVal)) {
-            curVal.replace(newVal);
-        }        
-        else if( ("set" in curVal) && (isPlainObject(newVal) || isArray(newVal))) {
-            curVal.set(newVal, remove);
-        }
-        else if( ("attr" in curVal) && (isPlainObject(newVal) || isArray(newVal)) ) {
-            curVal.attr(newVal, remove);
-        }
-        else if(curVal !== newVal) {
-            self.set(prop, newVal);
-        }
-        delete props[prop];
-    }, this, false);
+		if (newVal === undefined) {
+			if (remove) {
+				self[prop] = undefined;
+			}
+			return;
+		}
+		if (typeof curVal !== "object" || curVal === null) {
+			self.set(prop, newVal);
+		}
+		else if (("replace" in curVal) && isArray(newVal)) {
+			curVal.replace(newVal);
+		}
+		else if (("set" in curVal) && (isPlainObject(newVal) || isArray(newVal))) {
+			curVal.set(newVal, remove);
+		}
+		else if (("attr" in curVal) && (isPlainObject(newVal) || isArray(newVal))) {
+			curVal.attr(newVal, remove);
+		}
+		else if (curVal !== newVal) {
+			self.set(prop, newVal);
+		}
+		delete props[prop];
+	}, this, false);
     // Add remaining props.
-    for (prop in props) {
+	for (prop in props) {
         // Ignore _cid.
-        if (prop !== "_cid") {
-            newVal = props[prop];
-            this.set(prop, newVal);
-        }
+		if (prop !== "_cid") {
+			newVal = props[prop];
+			this.set(prop, newVal);
+		}
 
-    }
-    canBatch.stop();
-    return this;
+	}
+	canBatch.stop();
+	return this;
 };
 
-var DefineMap = Construct.extend("DefineMap",{
-    setup: function(base){
-        if(DefineMap) {
-            var prototype = this.prototype;
-            define(prototype, prototype, base.prototype._define);
+var DefineMap = Construct.extend("DefineMap", {
+	setup: function(base) {
+		if (DefineMap) {
+			var prototype = this.prototype;
+			define(prototype, prototype, base.prototype._define);
 
-            this.prototype.setup = function(props){
-                define.setup.call(this, defineHelpers.toObject(this, props,{}, DefineMap), this.constructor.seal);
-            };
-        }
-    }
-},{
+			this.prototype.setup = function(props) {
+				define.setup.call(this, defineHelpers.toObject(this, props, {}, DefineMap), this.constructor.seal);
+			};
+		}
+	}
+}, {
     // setup for only dynamic DefineMap instances
-    setup: function(props, sealed){
-        if(!this._define) {
-            Object.defineProperty(this,"_define",{
-                enumerable: false,
-                value: {
-                    definitions: {}
-                }
-            });
-            Object.defineProperty(this,"_data",{
-                enumerable: false,
-                value: {}
-            });
-        }
-        define.setup.call(this, defineHelpers.toObject(this, props,{}, DefineMap), sealed === true);
-    },
+	setup: function(props, sealed) {
+		if (!this._define) {
+			Object.defineProperty(this, "_define", {
+				enumerable: false,
+				value: {
+					definitions: {}
+				}
+			});
+			Object.defineProperty(this, "_data", {
+				enumerable: false,
+				value: {}
+			});
+		}
+		define.setup.call(this, defineHelpers.toObject(this, props, {}, DefineMap), sealed === true);
+	},
     /**
      * @function can-define/map/map.prototype.get get
      * @parent can-define/map/map.prototype
@@ -148,20 +148,22 @@ var DefineMap = Construct.extend("DefineMap",{
      *   @param {String} propName The property name of a property that may not have been defined yet.
      *   @return {*} The value of that property.
      */
-    get: function(prop){
-        if(prop) {
-            var value = this[prop];
-            if(value !== undefined || prop in this || Object.isSealed(this)) {
-                return value;
-            } else {
-                Observation.add(this, prop);
-                return this[prop];
-            }
+	get: function(prop) {
+		if (prop) {
+			var value = this[prop];
+			if (value !== undefined || prop in this || Object.isSealed(this)) {
+				return value;
+			}
+			else {
+				Observation.add(this, prop);
+				return this[prop];
+			}
 
-        } else {
-            return defineHelpers.serialize(this, 'get', {});
-        }
-    },
+		}
+		else {
+			return defineHelpers.serialize(this, 'get', {});
+		}
+	},
     /**
      * @function can-define/map/map.prototype.set set
      * @parent can-define/map/map.prototype
@@ -190,16 +192,16 @@ var DefineMap = Construct.extend("DefineMap",{
      *   @param {*} value The value to assign to `propName`.
      *   @return {can-define/map/map} This map instance, for chaining.
      */
-    set: function(prop, value){
-        if(typeof prop === "object") {
-            return setProps.call(this, prop, value);
-        }
-        var defined = defineHelpers.defineExpando(this, prop, value);
-        if(!defined) {
-            this[prop] = value;
-        }
-        return this;
-    },
+	set: function(prop, value) {
+		if (typeof prop === "object") {
+			return setProps.call(this, prop, value);
+		}
+		var defined = defineHelpers.defineExpando(this, prop, value);
+		if (!defined) {
+			this[prop] = value;
+		}
+		return this;
+	},
     /**
      * @function can-define/map/map.prototype.serialize serialize
      * @parent can-define/map/map.prototype
@@ -232,53 +234,53 @@ var DefineMap = Construct.extend("DefineMap",{
      *   @return {Object} A JavaScript Object that can be serialized with `JSON.stringify` or other methods.
      *
      */
-    serialize: function () {
-        return defineHelpers.serialize(this, 'serialize', {});
-    },
+	serialize: function() {
+		return defineHelpers.serialize(this, 'serialize', {});
+	},
 
-    forEach: function(cb, thisarg, observe){
-        if(observe !== false) {
-            Observation.add(this, '__keys');
-        }
-        var res;
-        var constructorDefinitions = this._define.definitions;
-        if(constructorDefinitions) {
-            res = eachDefinition(this, cb, thisarg, constructorDefinitions, observe);
-        }
-        if(res === false) {
-            return this;
-        }
-        if(this._instanceDefinitions) {
-            eachDefinition(this, cb, thisarg, this._instanceDefinitions, observe);
-        }
+	forEach: function(cb, thisarg, observe) {
+		if (observe !== false) {
+			Observation.add(this, '__keys');
+		}
+		var res;
+		var constructorDefinitions = this._define.definitions;
+		if (constructorDefinitions) {
+			res = eachDefinition(this, cb, thisarg, constructorDefinitions, observe);
+		}
+		if (res === false) {
+			return this;
+		}
+		if (this._instanceDefinitions) {
+			eachDefinition(this, cb, thisarg, this._instanceDefinitions, observe);
+		}
 
-        return this;
-    },
-    "*": {
-        type: define.types.observable
-    }
+		return this;
+	},
+	"*": {
+		type: define.types.observable
+	}
 });
 
 // Add necessary event methods to this object.
-for(var prop in define.eventsProto) {
-    DefineMap[prop] = define.eventsProto[prop];
-    Object.defineProperty(DefineMap.prototype, prop, {
-        enumerable:false,
-        value: define.eventsProto[prop],
-        writable: true
-    });
+for (var prop in define.eventsProto) {
+	DefineMap[prop] = define.eventsProto[prop];
+	Object.defineProperty(DefineMap.prototype, prop, {
+		enumerable: false,
+		value: define.eventsProto[prop],
+		writable: true
+	});
 }
 types.DefineMap = DefineMap;
 types.DefaultMap = DefineMap;
 
-DefineMap.prototype.toObject = function(){
-    canLog.warn("Use DefineMap::get instead of DefineMap::toObject");
-    return this.get();
+DefineMap.prototype.toObject = function() {
+	canLog.warn("Use DefineMap::get instead of DefineMap::toObject");
+	return this.get();
 };
 DefineMap.prototype.each = DefineMap.prototype.forEach;
 
 var oldIsMapLike = types.isMapLike;
-types.isMapLike = function(obj){
+types.isMapLike = function(obj) {
 	return obj instanceof DefineMap || oldIsMapLike.apply(this, arguments);
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -11,107 +11,107 @@ var QUnit = require("steal-qunit");
 
 QUnit.module("can-define: map and list combined");
 
-QUnit.test("basics", function(){
-    var items = new DefineMap({ people: [{name: "Justin"},{name: "Brian"}], count: 1000 });
-    QUnit.ok(items.people instanceof types.DefineList, "people is list");
-    QUnit.ok(items.people.item(0) instanceof types.DefineMap, "1st object is Map");
-    QUnit.ok(items.people.item(1) instanceof types.DefineMap, "2nd object is Map");
-    QUnit.equal(items.people.item(1).name, "Brian", "2nd object's name is right");
-    QUnit.equal(items.count, 1000, "count is number");
+QUnit.test("basics", function() {
+	var items = new DefineMap({ people: [ { name: "Justin" }, { name: "Brian" } ], count: 1000 });
+	QUnit.ok(items.people instanceof types.DefineList, "people is list");
+	QUnit.ok(items.people.item(0) instanceof types.DefineMap, "1st object is Map");
+	QUnit.ok(items.people.item(1) instanceof types.DefineMap, "2nd object is Map");
+	QUnit.equal(items.people.item(1).name, "Brian", "2nd object's name is right");
+	QUnit.equal(items.count, 1000, "count is number");
 });
 
-QUnit.test("serialize works", function(){
-    var Person = DefineMap.extend({
-        first: "string",
-        last: "string"
-    });
-    var People = DefineList.extend({
-        "*": Person
-    });
-
-    var people = new People([{first: "j", last: "m"}]);
-    QUnit.deepEqual(people.serialize(), [{first: "j", last: "m"}]);
-
-});
-
-QUnit.test("Extended Map with empty def converts to default Observables", function(){
-    var School = DefineMap.extend({
-        students: {},
-        teacher: {}
-    });
-
-    var school = new School();
-
-    school.students = [{name: "J"}];
-    school.teacher = {name: "M"};
-
-    ok(school.students instanceof types.DefineList, "converted to DefineList");
-    ok(school.teacher instanceof types.DefineMap, "converted to DefineMap");
-
-});
-
-QUnit.test("default 'observable' type prevents Type from working (#29)", function(){
-    var M = DefineMap.extend("M",{
-        id: "number"
-    });
-    var L = DefineList.extend("L",{
-        "*": M
-    });
-
-    var MyMap = DefineMap.extend({
-        l: L
-    });
-
-    var m = new MyMap({
-        l: [{id: 5}]
-    });
-
-    QUnit.ok( m.l[0] instanceof M, "is instance" );
-    QUnit.ok(m.l[0].id, 5, "correct props");
-});
-
-QUnit.test("inline DefineList Type", function(){
-    var M = DefineMap.extend("M",{
-        id: "number"
-    });
-
-    var MyMap = DefineMap.extend({
-        l: {Type: [M]}
-    });
-
-    var m = new MyMap({
-        l: [{id: 5}]
-    });
-
-    QUnit.ok( m.l[0] instanceof M, "is instance" );
-    QUnit.ok(m.l[0].id, 5, "correct props");
-});
-
-QUnit.test("recursively `get`s (#31)", function(){
-    var M = DefineMap.extend("M",{
-        id: "number"
-    });
-
-    var MyMap = DefineMap.extend({
-        l: {Type: [M]}
-    });
-
-    var m = new MyMap({
-        l: [{id: 5}]
-    });
-
-    var res = m.get();
-    QUnit.ok( isArray(res.l), "is a plain array");
-    QUnit.ok( isPlainObject(res.l[0]), "plain object");
-});
-
-QUnit.test("DefineList trigger deprecation warning when set with Map.set (#93)", 0, function(){
-	var map = new DefineMap({
-		things: [{ foo: 'bar' }]
+QUnit.test("serialize works", function() {
+	var Person = DefineMap.extend({
+		first: "string",
+		last: "string"
 	});
-	map.things.attr = function(){
+	var People = DefineList.extend({
+		"*": Person
+	});
+
+	var people = new People([ { first: "j", last: "m" } ]);
+	QUnit.deepEqual(people.serialize(), [ { first: "j", last: "m" } ]);
+
+});
+
+QUnit.test("Extended Map with empty def converts to default Observables", function() {
+	var School = DefineMap.extend({
+		students: {},
+		teacher: {}
+	});
+
+	var school = new School();
+
+	school.students = [ { name: "J" } ];
+	school.teacher = { name: "M" };
+
+	ok(school.students instanceof types.DefineList, "converted to DefineList");
+	ok(school.teacher instanceof types.DefineMap, "converted to DefineMap");
+
+});
+
+QUnit.test("default 'observable' type prevents Type from working (#29)", function() {
+	var M = DefineMap.extend("M", {
+		id: "number"
+	});
+	var L = DefineList.extend("L", {
+		"*": M
+	});
+
+	var MyMap = DefineMap.extend({
+		l: L
+	});
+
+	var m = new MyMap({
+		l: [ { id: 5 } ]
+	});
+
+	QUnit.ok(m.l[0] instanceof M, "is instance");
+	QUnit.ok(m.l[0].id, 5, "correct props");
+});
+
+QUnit.test("inline DefineList Type", function() {
+	var M = DefineMap.extend("M", {
+		id: "number"
+	});
+
+	var MyMap = DefineMap.extend({
+		l: { Type: [ M ] }
+	});
+
+	var m = new MyMap({
+		l: [ { id: 5 } ]
+	});
+
+	QUnit.ok(m.l[0] instanceof M, "is instance");
+	QUnit.ok(m.l[0].id, 5, "correct props");
+});
+
+QUnit.test("recursively `get`s (#31)", function() {
+	var M = DefineMap.extend("M", {
+		id: "number"
+	});
+
+	var MyMap = DefineMap.extend({
+		l: { Type: [ M ] }
+	});
+
+	var m = new MyMap({
+		l: [ { id: 5 } ]
+	});
+
+	var res = m.get();
+	QUnit.ok(isArray(res.l), "is a plain array");
+	QUnit.ok(isPlainObject(res.l[0]), "plain object");
+});
+
+QUnit.test("DefineList trigger deprecation warning when set with Map.set (#93)", 0, function() {
+	var map = new DefineMap({
+		things: [ { foo: 'bar' } ]
+	});
+	map.things.attr = function() {
 		ok(false, "attr should not be called");
 	};
 
-	map.set({ things: [{ baz: 'luhrmann' }] });
+	map.set({ things: [ { baz: 'luhrmann' } ] });
 });


### PR DESCRIPTION
DefineMap and DefineList are iterable, according to can-util/is-iterable.

At the moment, it only tests if it is, not if the values are as expected. I'm not sure how to test if it is iterable without `for (var item of set) {...}`, which is ES6. That test was written for both, but is currently commented out.

The iterators produced by `define.Iterator` follow the same pattern as the one produced by `new Map().entries()` (that is, the items are arrays, each with the key and value). Using an array in a for-of, however, produces a different kind of iterator, where the items are just the values, and the indexes are lost. As DefineList is using define.Iterator, it's iterator is a Map-type, instead of Array-type. Is this an issue?