### PR TITLE
standardize length event triggering

### DIFF
--- a/list/docs/events.length.md
+++ b/list/docs/events.length.md
@@ -13,7 +13,7 @@ list.on("length", function(event, length){ ... });
 ```
 
 It's possible that the length was not changed, but an item was [can-define/list/list::set] on the list.
-In this case, a `length` event will still be fired.
+In this case, a `length` event will not be fired.
 
   @param {Event} event An event object.
   @param {Number} length The new length of the list.

--- a/list/docs/events.length.md
+++ b/list/docs/events.length.md
@@ -13,7 +13,7 @@ list.on("length", function(event, length){ ... });
 ```
 
 It's possible that the length was not changed, but an item was [can-define/list/list::set] on the list.
-In this case, a `length` event will not be fired.
+In this case, a `length` event will still be fired.
 
   @param {Event} event An event object.
   @param {Number} length The new length of the list.

--- a/list/list-test.js
+++ b/list/list-test.js
@@ -165,7 +165,7 @@ test('splice removes items in IE (#562)', function() {
 
 
 test('reverse triggers add/remove events (#851)', function() {
-	expect(5);
+	expect(3);
 	var l = new DefineList([ 1, 2, 3 ]);
 
 	l.on('add', function() {
@@ -175,7 +175,7 @@ test('reverse triggers add/remove events (#851)', function() {
 		ok(true, 'remove called');
 	});
 	l.on('length', function() {
-		ok(true, 'length should be called');
+		ok(false, 'length should not be called');
 	});
 
 	l.reverse();
@@ -848,4 +848,35 @@ test("replace-with-self lists are diffed properly (can-view-live#10)", function(
 		equal(where, 2, "list2 removed location");
 	});
 	list2.replace([ a, b, d ]);
+});
+
+QUnit.test("set >= length - triggers length event (#152)", function() {
+	var l = new DefineList([ 1, 2, 3 ]);
+	l.on('length', function() {
+		ok(true, 'length should be called only once');
+	});
+
+	expect(2);
+	l.set(3, 5);
+
+	deepEqual(l.get(), [ 1, 2, 3, 5 ], "updated list");
+});
+
+test("set < length - does not trigger length event (#150)", function() {
+	var l = new DefineList([ 1, 2, 3 ]);
+
+	l.on("add", function() {
+		ok(true, "add called");
+	});
+	l.on("remove", function() {
+		ok(true, "remove called");
+	});
+	l.on("length", function() {
+		ok(false, "length should not be called");
+	});
+
+	expect(3);
+	l.set(2, 4);
+
+	deepEqual(l.get(), [ 1, 2, 4 ], "updated list");
 });

--- a/list/list-test.js
+++ b/list/list-test.js
@@ -165,7 +165,7 @@ test('splice removes items in IE (#562)', function() {
 
 
 test('reverse triggers add/remove events (#851)', function() {
-	expect(3);
+	expect(4);
 	var l = new DefineList([ 1, 2, 3 ]);
 
 	l.on('add', function() {
@@ -175,7 +175,7 @@ test('reverse triggers add/remove events (#851)', function() {
 		ok(true, 'remove called');
 	});
 	l.on('length', function() {
-		ok(false, 'length should not be called');
+		ok(true, 'length should be called');
 	});
 
 	l.reverse();
@@ -852,17 +852,24 @@ test("replace-with-self lists are diffed properly (can-view-live#10)", function(
 
 QUnit.test("set >= length - triggers length event (#152)", function() {
 	var l = new DefineList([ 1, 2, 3 ]);
-	l.on('length', function() {
-		ok(true, 'length should be called only once');
+
+	l.on("add", function() {
+		ok(true, "add called");
+	});
+	l.on("remove", function() {
+		ok(false, "remove called");
+	});
+	l.on("length", function() {
+		ok(true, "length called");
 	});
 
-	expect(2);
+	expect(3);
 	l.set(3, 5);
 
 	deepEqual(l.get(), [ 1, 2, 3, 5 ], "updated list");
 });
 
-test("set < length - does not trigger length event (#150)", function() {
+QUnit.test("set < length - triggers length event (#150)", function() {
 	var l = new DefineList([ 1, 2, 3 ]);
 
 	l.on("add", function() {
@@ -872,11 +879,33 @@ test("set < length - does not trigger length event (#150)", function() {
 		ok(true, "remove called");
 	});
 	l.on("length", function() {
-		ok(false, "length should not be called");
+		ok(true, "length called");
 	});
 
-	expect(3);
+	expect(4);
 	l.set(2, 4);
 
 	deepEqual(l.get(), [ 1, 2, 4 ], "updated list");
+});
+
+QUnit.test("set/splice are observable", function() {
+	var list = new DefineList([ 1, 2, 3, 4, 5 ]);
+
+	var count = new Observation(function() {
+		var count = 0;
+		for (var i = 0; i < list.length; i++) {
+			count += (list[i] % 2) ? 1 : 0;
+		}
+		return count;
+	}, null, {
+		updater: function() {
+			ok(true);
+		}
+	});
+	count.start();
+
+	expect(3);
+	list.set(3, 5);
+	list.set(2, 4);
+	list.splice(1, 1, 1);
 });

--- a/list/list-test.js
+++ b/list/list-test.js
@@ -857,18 +857,40 @@ test("replace-with-self lists are diffed properly (can-view-live#10)", function(
 
 QUnit.test("set >= length - triggers length event (#152)", function() {
 	var l = new DefineList([ 1, 2, 3 ]);
+	var batchNum = null;
 
-	l.on("add", function() {
+	l.on("add", function(e) {
 		ok(true, "add called");
+
+		if (batchNum === null) {
+			batchNum = e.batchNum;
+		}
+		else {
+			equal(batchNum, e.batchNum, "batch numbers match");
+		}
 	});
-	l.on("remove", function() {
+	l.on("remove", function(e) {
 		ok(false, "remove called");
+
+		if (batchNum === null) {
+			batchNum = e.batchNum;
+		}
+		else {
+			equal(batchNum, e.batchNum, "batch numbers match");
+		}
 	});
-	l.on("length", function() {
+	l.on("length", function(e) {
 		ok(true, "length called");
+
+		if (batchNum === null) {
+			batchNum = e.batchNum;
+		}
+		else {
+			equal(batchNum, e.batchNum, "batch numbers match");
+		}
 	});
 
-	expect(3);
+	expect(4);
 	l.set(3, 5);
 
 	deepEqual(l.get(), [ 1, 2, 3, 5 ], "updated list");
@@ -876,18 +898,40 @@ QUnit.test("set >= length - triggers length event (#152)", function() {
 
 QUnit.test("set < length - triggers length event (#150)", function() {
 	var l = new DefineList([ 1, 2, 3 ]);
+	var batchNum = null;
 
-	l.on("add", function() {
+	l.on("add", function(e) {
 		ok(true, "add called");
+
+		if (batchNum === null) {
+			batchNum = e.batchNum;
+		}
+		else {
+			equal(batchNum, e.batchNum, "batch numbers match");
+		}
 	});
-	l.on("remove", function() {
+	l.on("remove", function(e) {
 		ok(true, "remove called");
+
+		if (batchNum === null) {
+			batchNum = e.batchNum;
+		}
+		else {
+			equal(batchNum, e.batchNum, "batch numbers match");
+		}
 	});
-	l.on("length", function() {
+	l.on("length", function(e) {
 		ok(true, "length called");
+
+		if (batchNum === null) {
+			batchNum = e.batchNum;
+		}
+		else {
+			equal(batchNum, e.batchNum, "batch numbers match");
+		}
 	});
 
-	expect(4);
+	expect(6);
 	l.set(2, 4);
 
 	deepEqual(l.get(), [ 1, 2, 4 ], "updated list");

--- a/list/list.js
+++ b/list/list.js
@@ -372,9 +372,7 @@ var DefineList = Construct.extend("DefineList",
 				this._triggerChange("" + index, "add", added, removed);
 			}
 
-			if (added.length !== removed.length) {
-				canEvent.dispatch.call(this, 'length', [ this._length ]);
-			}
+			canEvent.dispatch.call(this, 'length', [ this._length ]);
 
 			canBatch.stop();
 			return removed;

--- a/list/list.js
+++ b/list/list.js
@@ -78,8 +78,6 @@ var DefineList = Construct.extend("DefineList",
 		__type: define.types.observable,
 		_triggerChange: function(attr, how, newVal, oldVal) {
 
-			canBatch.start();
-
 			var index = +attr;
 			// `batchTrigger` direct add and remove events...
 
@@ -107,7 +105,6 @@ var DefineList = Construct.extend("DefineList",
 				}, [ newVal, oldVal ]);
 			}
 
-			canBatch.stop();
 		},
 		/**
 		 * @function can-define/list/list.prototype.get get
@@ -413,7 +410,6 @@ var getArgs = function(args) {
 		args[0] :
 		makeArray(args);
 };
-
 // Create `push`, `pop`, `shift`, and `unshift`
 each({
 		/**
@@ -536,8 +532,10 @@ each({
 			res = orig.apply(this, args);
 
 			if (!this.comparator || args.length) {
+				canBatch.start();
 				this._triggerChange("" + len, "add", args, undefined);
 				canEvent.dispatch.call(this, 'length', [ this._length ]);
+				canBatch.stop();
 			}
 
 			return res;
@@ -638,8 +636,10 @@ each({
 			// `remove` - Items removed.
 			// `undefined` - The new values (there are none).
 			// `res` - The old, removed values (should these be unbound).
+			canBatch.start();
 			this._triggerChange("" + len, "remove", undefined, [ res ]);
 			canEvent.dispatch.call(this, 'length', [ this._length ]);
+			canBatch.stop();
 
 			return res;
 		};

--- a/list/list.js
+++ b/list/list.js
@@ -92,13 +92,11 @@ var DefineList = Construct.extend("DefineList",
 						Observation.ignore(itemsDefinition.added).call(this, newVal, index);
 					}
 					canEvent.dispatch.call(this, how, [ newVal, index ]);
-					canEvent.dispatch.call(this, 'length', [ this._length ]);
 				} else if (how === 'remove') {
 					if (itemsDefinition && typeof itemsDefinition.removed === 'function') {
 						Observation.ignore(itemsDefinition.removed).call(this, oldVal, index);
 					}
 					canEvent.dispatch.call(this, how, [ oldVal, index ]);
-					canEvent.dispatch.call(this, 'length', [ this._length ]);
 				} else {
 					canEvent.dispatch.call(this, how, [ newVal, index ]);
 				}
@@ -373,6 +371,11 @@ var DefineList = Construct.extend("DefineList",
 			if (args.length > 2) {
 				this._triggerChange("" + index, "add", added, removed);
 			}
+
+			if (added.length !== removed.length) {
+				canEvent.dispatch.call(this, 'length', [ this._length ]);
+			}
+
 			canBatch.stop();
 			return removed;
 		},
@@ -412,6 +415,7 @@ var getArgs = function(args) {
 		args[0] :
 		makeArray(args);
 };
+
 // Create `push`, `pop`, `shift`, and `unshift`
 each({
 		/**
@@ -534,8 +538,8 @@ each({
 			res = orig.apply(this, args);
 
 			if (!this.comparator || args.length) {
-
 				this._triggerChange("" + len, "add", args, undefined);
+				canEvent.dispatch.call(this, 'length', [ this._length ]);
 			}
 
 			return res;
@@ -637,6 +641,7 @@ each({
 			// `undefined` - The new values (there are none).
 			// `res` - The old, removed values (should these be unbound).
 			this._triggerChange("" + len, "remove", undefined, [ res ]);
+			canEvent.dispatch.call(this, 'length', [ this._length ]);
 
 			return res;
 		};


### PR DESCRIPTION
Fixes the triggering of `length` events to only trigger when the length changes (#150), and only once (#152). Previously, a change or replace (as opposed to an addition or removal) would trigger 2 changes, as it was treated as an add and a remove, both of which triggered `length`. A simple change (`[1, 2, 3] => [1, 4, 3]`) now produces no `length`, and a replace only produces one if the new length is different. A single push/pop/shift/unshift still only produces 1 event.

Previously, reverse produced 2 events (as it is just a replace), but [there was a test](https://github.com/canjs/can-define/blob/master/list/list-test.js#L178) which verified the existence of both events. That test references issues #851 which does not exist (was this perhaps originally in a different repo?). I have modified that test, but am unable to track down the reason for it, and thus cannot verify that this will not break what that fixed.

fixes #150, fixes #152