### PR TITLE
fix map return type (#153)

### DIFF
--- a/list/list-test.js
+++ b/list/list-test.js
@@ -371,7 +371,12 @@ test('list.map', function() {
 		person.lastName = "Thompson";
 		return person;
 	});
-	QUnit.equal("It Worked!", newExtendedList.testMe(), 'Returns the same type of list.');
+	QUnit.throws(function() {
+		newExtendedList.testMe();
+	}, {
+		name: 'TypeError',
+		message: 'newExtendedList.testMe is not a function'
+	}, 'Does not return the same type of list.');
 });
 
 

--- a/list/list.js
+++ b/list/list.js
@@ -1009,7 +1009,7 @@ assign(DefineList.prototype, {
 			mappedList.push(mapped);
 
 		});
-		return new this.constructor(mappedList);
+		return new DefineList(mappedList);
 	},
 
 	/**


### PR DESCRIPTION
Fixes #153 by return a plain DefineList on `.map()` calls.