### PR TITLE
length setter

### DIFF
--- a/list/list-test.js
+++ b/list/list-test.js
@@ -827,7 +827,7 @@ QUnit.test("Array shorthand uses #", function() {
 	QUnit.ok(map.numbers.prop === "4", "type left alone");
 });
 
-test("replace-with-self lists are diffed properly (can-view-live#10)", function() {
+QUnit.test("replace-with-self lists are diffed properly (can-view-live#10)", function() {
 	var a = new DefineMap({ name: "A" });
 	var b = new DefineMap({ name: "B" });
 	var c = new DefineMap({ name: "C" });
@@ -853,4 +853,32 @@ test("replace-with-self lists are diffed properly (can-view-live#10)", function(
 		equal(where, 2, "list2 removed location");
 	});
 	list2.replace([ a, b, d ]);
+});
+
+QUnit.test("setting length > current (#147)", function() {
+	var list = new DefineList([ 1, 2 ]);
+
+	list.length = 5;
+
+	equal(list.length, 5);
+	equal(list.hasOwnProperty(0), true);
+	equal(list.hasOwnProperty(1), true);
+	equal(list.hasOwnProperty(2), true);
+	equal(list.hasOwnProperty(3), true);
+	equal(list.hasOwnProperty(4), true);
+	equal(list.hasOwnProperty(5), false);
+});
+
+QUnit.test("setting length < current (#147)", function() {
+	var list = new DefineList([ 1, 2, 3, 4, 5 ]);
+
+	list.length = 3;
+
+	equal(list.length, 3);
+	equal(list.hasOwnProperty(0), true);
+	equal(list.hasOwnProperty(1), true);
+	equal(list.hasOwnProperty(2), true);
+	equal(list.hasOwnProperty(3), false);
+	equal(list.hasOwnProperty(4), false);
+	equal(list.hasOwnProperty(5), false);
 });

--- a/list/list.js
+++ b/list/list.js
@@ -1088,8 +1088,25 @@ Object.defineProperty(DefineList.prototype, "length", {
 		}
 		return this._length;
 	},
-	set: function(newVal) {
-		this._length = newVal;
+	set: function(newLength) {
+		if (newLength === this._length) {
+			return;
+		}
+
+		if (newLength > this._length - 1) {
+			for (var i = this._length; i < newLength; i++) {
+				if (!this.hasOwnProperty(i)) {
+					this[i] = undefined;
+				}
+			}
+		}
+		else {
+			for (var i = newLength; i < this._length; i++) {
+				delete this[i];
+			}
+		}
+
+		this._length = newLength;
 	},
 	enumerable: true
 });


### PR DESCRIPTION
Updates can-define/list to have a length setter which actually mutates the information stored. If the set length > the current length, the extra values are set to undefined with `.push` (much like when `set`ting a position greater than the current length). If the set length < the current length, extra values are removed via `.splice`.

One issue that I ran into is that the native `splice`, `push`, `pop`, `shift`, and `unshift` each will trigger the length setter. My first solution (see first commit) implemented the functionality of these calls manually, but I realized it wouldn't fire events correctly. I switched to using the already existing `push`/`splice`, but since there is no way to tell the difference between the length setter being called directly vs via one of those methods, I had to wrap the calls to those in a `_isProcessing` flag. When the flag is set, the setter acts as it did before (just setting the `_length` value), and only mutates the list when it is not set.

fixed #147