### PR TITLE
Fix #174 (DefineMap.keys should return serialize: true properties)

### DIFF
--- a/map/map-test.js
+++ b/map/map-test.js
@@ -649,3 +649,26 @@ QUnit.test(".value functions should not be observable", function(){
 	
 	equal(count, 1);
 });
+
+QUnit.test("DefineMap.keys returns serialize: true properties (#174)", function () {
+	var Foo = DefineMap.extend({
+		first: "string",
+		last: "string",
+		fullName: {
+			get: function () {
+				return this.first + this.last;
+			},
+			serialize: true
+		},
+		greeting: {
+			get: function () {
+				return "hello " + this.fullName();
+			}
+		}
+	});
+	var foo = new Foo();
+
+	var keys = DefineMap.keys(foo);
+
+	QUnit.equal(keys[0], "fullName", "DefineMap.keys returns only serialize: true properties");
+});

--- a/map/map.js
+++ b/map/map.js
@@ -105,6 +105,16 @@ var DefineMap = Construct.extend("DefineMap",{
         }
     }
 		define.defineConfigurableAndNotEnumerable(prototype, "constructor", this);
+	},
+
+	keys: function (map) {
+		var keys = [], definitions = map._define.definitions;
+		for (var keyName in definitions) {
+			if (definitions[keyName]['serialize']) {
+				keys.push(keyName);
+			}
+		}
+		return keys;
 	}
 },{
     // setup for only dynamic DefineMap instances


### PR DESCRIPTION
Add "keys" function to static properties of DefineMap. Make it iterate over all define definitions and return only those properties which have "serialize" set to true

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
