### PR TITLE
chore(package): update can-util to version 3.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "can-namespace": "^1.0.0",
     "can-observation": "^3.0.1",
     "can-types": "^1.0.1",
-    "can-util": "^3.1.1"
+    "can-util": "^3.5.1"
   },
   "devDependencies": {
     "can-list": "^3.0.1",


### PR DESCRIPTION
Explicitly upgrading to can-util > 3.4.0 to try to resolve https://github.com/canjs/can-define/issues/182.