### PR TITLE
Updating list-test.js to not use QUnit.throws

### DIFF
--- a/list/list-test.js
+++ b/list/list-test.js
@@ -371,12 +371,12 @@ test('list.map', function() {
 		person.lastName = "Thompson";
 		return person;
 	});
-	QUnit.throws(function() {
+
+	try {
 		newExtendedList.testMe();
-	}, {
-		name: 'TypeError',
-		message: 'newExtendedList.testMe is not a function'
-	}, 'Does not return the same type of list.');
+	} catch(err) {
+		equal(err.message, 'newExtendedList.testMe is not a function');
+	}
 });
 
 


### PR DESCRIPTION
Fixes https://github.com/canjs/can-define/issues/191