### PR TITLE
make define properties enumerable

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -721,6 +721,16 @@ define.setup = function(props, sealed) {
 	var definitions = this._define.definitions;
 	var instanceDefinitions = Object.create(null);
 	var map = this;
+
+	each(definitions, function(value, prop) {
+		var parent = Object.getOwnPropertyDescriptor(map.constructor.prototype, prop);
+		Object.defineProperty(map, prop, {
+			enumerable: true,
+			get: parent.get,
+			set: parent.set
+		});
+	});
+
 	each(props, function(value, prop){
 		if(definitions[prop]) {
 			map[prop] = value;

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -509,7 +509,7 @@ QUnit.test("copying with assign() excludes special keys", function() {
 	QUnit.notEqual(a._cid, b._cid, "_cid prop not copied");
 	QUnit.equal(a.foo, b.foo, "New props copied");
 	QUnit.equal(a.existing, b.existing, "Existing props copied");
-	
+
 });
 
 QUnit.test("shorthand getter setter (#56)", function(){
@@ -623,7 +623,7 @@ QUnit.test(".value functions should not be observable", function(){
 	var outer = new DefineMap({
 		bam: "baz"
 	});
-	
+
 	var ItemsVM = DefineMap.extend({
 		item: {
 			value: function(){
@@ -633,20 +633,20 @@ QUnit.test(".value functions should not be observable", function(){
 		},
 		zed: "string"
 	});
-	
+
 	var items = new ItemsVM();
-	
+
 	var count = 0;
 	var itemsList = compute(function(){
 		count++;
 		return items.item;
 	});
-	
+
 	itemsList.on('change', function() {});
-	
+
 	items.item.foo = "changed";
 	items.zed = "changed";
-	
+
 	equal(count, 1);
 });
 
@@ -662,4 +662,19 @@ QUnit.test(".value values are overwritten by props in DefineMap construction", f
 	});
 
 	equal(foo.bar, "quux", "Value set properly");
+});
+
+QUnit.test("keys are exposed via Object.keys()", function() {
+	var Foo = DefineMap.extend({
+		bar: {
+			value: "baz"
+		}
+	});
+
+	var foo = new Foo();
+
+	QUnit.deepEqual(Object.keys(foo), [ 'bar' ], "Value set properly");
+	QUnit.equal(foo.bar, 'baz');
+	foo.bar = 'bazzz';
+	QUnit.equal(foo.bar, 'bazzz');
 });


### PR DESCRIPTION
I ran some performance tests on this change as well. Reads/writes had a negligible change, as expected since it is just reusing the getters/setters. Creating instances of the component did have a 13% increase in time.

I am not sure how often new instances are created vs reading/writing existing instances, so I am unsure what the final impact would be. If the increase is deemed too great, I would propose that a method be added to the class (so that all instance of that class get it) or to the instance (only that instance gets it), to enable this functionality, something like `makeEnumerable()`.

## Why

When working on the RVM project, we realized that we need to be able to rest/spread DefineMaps, in order to support existing React developers and components. It is an extremely common, and extremely useful, style. Specifically, it would enable all of the following:

```javascript
const Foo = DefineMap.extend({
	bar: {
		value: "baz"
	}
});

let foo = new Foo();

Object.keys(foo)
Object.values(foo)
Object.entries(foo)
Object.assign({}, foo)

let { ...rest } = foo;
{ ...foo }
```