### PR TITLE
Replace duck-typing hasMethod with can-reflect

### DIFF
--- a/define-helpers/define-helpers.js
+++ b/define-helpers/define-helpers.js
@@ -4,11 +4,7 @@ var CID = require("can-cid");
 var define = require("can-define");
 var canBatch = require("can-event/batch/batch");
 var canEvent = require("can-event");
-
-
-var hasMethod = function(obj, method){
-	return obj && typeof obj === "object" && (method in obj);
-};
+var canReflect = require("can-reflect");
 
 var defineHelpers = {
 	extendedSetup: function(props){
@@ -86,7 +82,7 @@ var defineHelpers = {
 			}
 		}
 
-		if( hasMethod(val, how) ) {
+		if(canReflect.isObservableLike(val)) {
 			return val[how]();
 		} else {
 			return val;
@@ -127,7 +123,7 @@ var defineHelpers = {
 				// If the value is an `object`, and has an `attr` or `serialize` function.
 
 				var result,
-					isObservable =   hasMethod(val, how),
+					isObservable = canReflect.isObservableLike(val),
 					serialized = isObservable && serializeMap[how][CID(val)];
 
 				if( serialized ) {

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -798,3 +798,19 @@ QUnit.test("redefines still not allowed on sealed objects", function() {
 		QUnit.ok(!Object.getOwnPropertyDescriptor(baz._computed, "plonk"), "nothing set on _computed");
 	}
 });
+
+QUnit.test("Call .get() when a nested object has its own get method", function(){
+	var request = {
+		prop: 22,
+		get: function(){
+			if(arguments.length === 0) {
+				throw new Error("This function can't be called with 0 arguments");
+			}
+		}
+	};
+
+	var obj = new DefineMap({ request: request });
+	var data = obj.get();
+
+	QUnit.equal(data.request.prop, 22, "obj did get()");
+});

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -800,6 +800,10 @@ QUnit.test("redefines still not allowed on sealed objects", function() {
 });
 
 QUnit.test("Call .get() when a nested object has its own get method", function(){
+	var Bar = DefineMap.extend({
+		request: "*"
+	});
+
 	var request = {
 		prop: 22,
 		get: function(){
@@ -809,7 +813,7 @@ QUnit.test("Call .get() when a nested object has its own get method", function()
 		}
 	};
 
-	var obj = new DefineMap({ request: request });
+	var obj = new Bar({ request: request });
 	var data = obj.get();
 
 	QUnit.equal(data.request.prop, 22, "obj did get()");


### PR DESCRIPTION
This replaces the hasMethod function which could return false positives,
	 and did so with the case of Node.js request objects, with using
	 can-reflect to determine if an object is observable.

Closes #216