### PR TITLE
skipping Object.seal test in production

### DIFF
--- a/map/map-test.js
+++ b/map/map-test.js
@@ -766,38 +766,40 @@ QUnit.test("Does not attempt to redefine _data if already defined", function() {
 
 });
 
-QUnit.test("redefines still not allowed on sealed objects", function() {
-	QUnit.expect(6);
-	var Bar = DefineMap.extend({seal: true}, {
-		baz: { value : "thud" }
-	});
-	
-	var baz = new Bar();
-	
-	try {
-		define(baz, {
-			quux: { value: "jeek" }
-		}, baz._define);
-	} catch(e) {
-		QUnit.ok(/object is not extensible/i.test(e.message), "Sealed object throws on data property defines");
-		QUnit.ok(!Object.getOwnPropertyDescriptor(baz, "quux"), "nothing set on object");
-		QUnit.ok(!Object.getOwnPropertyDescriptor(baz._data, "quux"), "nothing set on _data");
-	}
+if (!System.isEnv('production')) {
+	QUnit.test("redefines still not allowed on sealed objects", function() {
+		QUnit.expect(6);
+		var Bar = DefineMap.extend({seal: true}, {
+			baz: { value : "thud" }
+		});
 
-	try {
-		define(baz, {
-			plonk: {
-				get: function() {
-					return "waldo";
+		var baz = new Bar();
+
+		try {
+			define(baz, {
+				quux: { value: "jeek" }
+			}, baz._define);
+		} catch(e) {
+			QUnit.ok(/object is not extensible/i.test(e.message), "Sealed object throws on data property defines");
+			QUnit.ok(!Object.getOwnPropertyDescriptor(baz, "quux"), "nothing set on object");
+			QUnit.ok(!Object.getOwnPropertyDescriptor(baz._data, "quux"), "nothing set on _data");
+		}
+
+		try {
+			define(baz, {
+				plonk: {
+					get: function() {
+						return "waldo";
+					}
 				}
-			}
-		}, baz._define);
-	} catch(e) {
-		QUnit.ok(/object is not extensible/i.test(e.message), "Sealed object throws on computed property defines");
-		QUnit.ok(!Object.getOwnPropertyDescriptor(baz, "plonk"), "nothing set on object");
-		QUnit.ok(!Object.getOwnPropertyDescriptor(baz._computed, "plonk"), "nothing set on _computed");
-	}
-});
+			}, baz._define);
+		} catch(e) {
+			QUnit.ok(/object is not extensible/i.test(e.message), "Sealed object throws on computed property defines");
+			QUnit.ok(!Object.getOwnPropertyDescriptor(baz, "plonk"), "nothing set on object");
+			QUnit.ok(!Object.getOwnPropertyDescriptor(baz._computed, "plonk"), "nothing set on _computed");
+		}
+	});
+}
 
 QUnit.test("Call .get() when a nested object has its own get method", function(){
 	var Bar = DefineMap.extend({


### PR DESCRIPTION
closes https://github.com/canjs/can-define/issues/218.