### PR TITLE
fixing .get() when CanMap is nested in a DefineMap

### DIFF
--- a/define-helpers/define-helpers.js
+++ b/define-helpers/define-helpers.js
@@ -83,7 +83,7 @@ var defineHelpers = {
 		}
 
 		if(canReflect.isObservableLike(val)) {
-			return val[how]();
+			return canReflect.getValue(val);
 		} else {
 			return val;
 		}
@@ -121,7 +121,6 @@ var defineHelpers = {
 			// Go through each property.
 			map.each(function (val, name) {
 				// If the value is an `object`, and has an `attr` or `serialize` function.
-
 				var result,
 					isObservable = canReflect.isObservableLike(val),
 					serialized = isObservable && serializeMap[how][CID(val)];
@@ -136,8 +135,6 @@ var defineHelpers = {
 				if(result !== undefined) {
 					where[name] = result;
 				}
-
-
 			});
 
 			if(firstSerialize) {

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1,6 +1,7 @@
 "use strict";
 var QUnit = require("steal-qunit");
 var DefineMap = require("can-define/map/map");
+var CanMap = require("can-map");
 var define = require("can-define");
 var Observation = require("can-observation");
 var each = require("can-util/js/each/each");
@@ -833,4 +834,12 @@ QUnit.test("DefineMap short-hand Type (#221)", function(){
 
 	QUnit.ok(c.other instanceof DefineMap, "is a DefineMap");
 
+});
+
+QUnit.test(".get() works with a nested CanMap (#224)", function() {
+	var myMap = new DefineMap({
+		other: new CanMap()
+	});
+
+	QUnit.deepEqual(myMap.get(), { other: {} }, "works");
 });

--- a/package.json
+++ b/package.json
@@ -43,13 +43,14 @@
     "can-util": "^3.9.0"
   },
   "devDependencies": {
+    "bit-docs": "^0.0.7",
+    "can-map": "^3.2.0",
     "jshint": "^2.9.1",
     "serve": "^5.1.4",
     "steal": "^1.0.7",
     "steal-qunit": "^1.0.0",
     "steal-tools": "^1.0.1",
-    "testee": "^0.5.0",
-    "bit-docs": "^0.0.7"
+    "testee": "^0.5.0"
   },
   "bit-docs": {
     "dependencies": {


### PR DESCRIPTION
closes https://github.com/canjs/can-define/issues/224.