### PR TITLE
Replace deprecated can-util/js/is-array with Array.isArray

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -14,7 +14,6 @@ var assign = require("can-util/js/assign/assign");
 var dev = require("can-util/js/dev/dev");
 var CID = require("can-cid");
 var isPlainObject = require("can-util/js/is-plain-object/is-plain-object");
-var isArray = require("can-util/js/is-array/is-array");
 var types = require("can-types");
 var each = require("can-util/js/each/each");
 var defaults = require("can-util/js/defaults/defaults");
@@ -474,7 +473,7 @@ make = {
 		},
 		Type: function(prop, Type, set) {
 			// `type`: {foo: "string"}
-			if(isArray(Type) && types.DefineList) {
+			if(Array.isArray(Type) && types.DefineList) {
 				Type = types.DefineList.extend({
 					"#": Type[0]
 				});
@@ -645,7 +644,7 @@ getDefinitionOrMethod = function(prop, value, defaultDefinition){
 			definition = {type: value};
 		}
 		// or leaves as a function
-	} else if( isArray(value) ) {
+	} else if( Array.isArray(value) ) {
 		definition = {Type: value};
 	} else if( isPlainObject(value) ){
 		definition = value;
@@ -906,7 +905,7 @@ define.types = {
 		return true;
 	},
 	'observable': function(newVal) {
-				if(isArray(newVal) && types.DefineList) {
+				if(Array.isArray(newVal) && types.DefineList) {
 						newVal = new types.DefineList(newVal);
 				}
 				else if(isPlainObject(newVal) &&  types.DefineMap) {
@@ -915,7 +914,7 @@ define.types = {
 				return newVal;
 		},
 	'stringOrObservable': function(newVal) {
-		if(isArray(newVal)) {
+		if(Array.isArray(newVal)) {
 			return new types.DefaultList(newVal);
 		}
 		else if(isPlainObject(newVal)) {

--- a/define-test.js
+++ b/define-test.js
@@ -3,7 +3,6 @@ var compute = require("can-compute");
 var define = require("can-define");
 var CanList = require("can-define/list/list");
 var canBatch = require("can-event/batch/batch");
-var isArray = require("can-util/js/is-array/is-array");
 var each = require("can-util/js/each/each");
 var canSymbol = require("can-symbol");
 
@@ -265,7 +264,7 @@ QUnit.test("basics value", function() {
 		t2 = new Typer2();
 
 	QUnit.ok(t1.prop !== t2.prop, "different array instances");
-	QUnit.ok(isArray(t1.prop), "its an array");
+	QUnit.ok(Array.isArray(t1.prop), "its an array");
 
 
 });
@@ -287,7 +286,7 @@ test("basics Value", function() {
 	var t1 = new Typer(),
 		t2 = new Typer();
 	QUnit.ok(t1.prop !== t2.prop, "different array instances");
-	QUnit.ok(isArray(t1.prop), "its an array");
+	QUnit.ok(Array.isArray(t1.prop), "its an array");
 
 
 });

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,6 @@ require("../map/map-test");
 require("../define-test");
 var DefineMap = require("can-define/map/map");
 var DefineList = require("can-define/list/list");
-var isArray = require("can-util/js/is-array/is-array");
 var isPlainObject = require("can-util/js/is-plain-object/is-plain-object");
 var types = require("can-types");
 
@@ -102,7 +101,7 @@ QUnit.test("recursively `get`s (#31)", function(){
     });
 
     var res = m.get();
-    QUnit.ok( isArray(res.l), "is a plain array");
+    QUnit.ok( Array.isArray(res.l), "is a plain array");
     QUnit.ok( isPlainObject(res.l[0]), "plain object");
 });
 


### PR DESCRIPTION
See https://github.com/canjs/can-util/issues/225. We are now using `Array.isArray` directly.