### PR TITLE
Observe on the object property

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -304,7 +304,10 @@ make = {
 					computeFn = defaultValue;
 					valueTrap = trapSets(computeFn);
 				} else {
-					computeFn = new Observation(boundGet, map);
+					computeFn = new Observation(boundGet, map, {
+						isObservable: false,
+						isProactivelyCacheable: true
+					});
 					valueTrap = trapSets(computeFn);
 					valueTrap.lastSetValue = defaultValue;
 				}

--- a/can-define.js
+++ b/can-define.js
@@ -125,6 +125,13 @@ module.exports = define = ns.define = function(objPrototype, defines, baseDefine
 		});
 	}
 
+	// Places a `_cid` on the prototype that when first called replaces itself
+	// with a `_cid` object local to the instance.
+	if (!objPrototype.hasOwnProperty("_cid")) {
+		replaceWith(objPrototype, "_cid", function() {
+			return CID({});
+		});
+	}	
 
 	// Add necessary event methods to this object.
 	for (prop in eventsProto) {

--- a/can-define.js
+++ b/can-define.js
@@ -581,6 +581,9 @@ make = {
 		},
 		computed: function(prop) {
 			return function() {
+				if (!this.__inSetup) {
+					Observation.add(this, prop);
+				}
 				return canReflect.getValue(this._computed[prop].compute);
 			};
 		}

--- a/define-test.js
+++ b/define-test.js
@@ -1400,3 +1400,15 @@ QUnit.test('reflect onKeyValue should be bound for property computes', function 
 	proxyValue.off('change', subscription);
 	unmock();
 });
+
+QUnit.test('define() should add a CID (#246)', function() {
+	var Greeting = function(message){
+		this.message = message;
+	};
+
+	define(Greeting.prototype, {
+		message: {type: "string"}
+	});
+	var g = new Greeting();
+	QUnit.ok(g._cid, "should have a CID property");
+});

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "can-construct": "^3.2.0",
     "can-event": "^3.5.0",
     "can-namespace": "^1.0.0",
-    "can-observation": "^3.3.0-pre.1",
+    "can-observation": "^3.3.4",
     "can-reflect": "^1.2.1",
     "can-symbol": "^1.0.0",
     "can-types": "^1.1.0",


### PR DESCRIPTION
Closes #149 

Note: the `this.__inSetup` check is included only to align with the `make.get.data` version.

Also closes #246.
