### PR TITLE
Removed redundant setting of keyValue functions

### DIFF
--- a/list/list-test.js
+++ b/list/list-test.js
@@ -1042,13 +1042,18 @@ QUnit.test("can-reflect onValue", function(assert) {
 });
 
 QUnit.test("can-reflect onKeyValue", function(assert) {
-	assert.expect(1);
+	assert.expect(3);
 	var list = new DefineList([1,2,3]);
 	var key = 1;
 	canReflect.onKeyValue(list, key, function(newVal) {
 		assert.equal(newVal, 5);
 	});
 	list.set(key, 5);
+
+	canReflect.onKeyValue(list, 'length', function(newVal) {
+		assert.equal(newVal, 4);
+	});
+	list.push(6);
 });
 
 test("works with can-reflect", function(){

--- a/list/list.js
+++ b/list/list.js
@@ -1309,19 +1309,6 @@ for (var prop in define.eventsProto) {
 		writable: true
 	});
 }
-// @@can.onKeyValue and @@can.offKeyValue are also on define.eventsProto
-//  but symbols are not enumerated in for...in loops
-var eventsProtoSymbols = ("getOwnPropertySymbols" in Object) ?
-  Object.getOwnPropertySymbols(define.eventsProto) :
-  [canSymbol.for("can.onKeyValue"), canSymbol.for("can.offKeyValue")];
-
-eventsProtoSymbols.forEach(function(sym) {
-  Object.defineProperty(DefineList.prototype, sym, {
-    enumerable:false,
-    value: define.eventsProto[sym],
-    writable: true
-  });
-});
 
 Object.defineProperty(DefineList.prototype, "length", {
 	get: function() {
@@ -1394,11 +1381,15 @@ canReflect.assignSymbols(DefineList.prototype,{
 	// Called for every reference to a property in a template
 	// if a key is a numerical index then translate to length event
 	"can.onKeyValue": function(key, handler) {
+		var translationHandler;
 		if (isNaN(key)) {
-			this.addEventListener(key, handler);
+			translationHandler = function(ev, newValue, oldValue) {
+				handler(newValue, oldValue);
+			};
+			this.addEventListener(key, translationHandler);
 		}
 		else {
-			var translationHandler = function() {
+			translationHandler = function() {
 				handler(this[key]);
 			};
 
@@ -1408,11 +1399,15 @@ canReflect.assignSymbols(DefineList.prototype,{
 	},
 	// Called when a property reference is removed
 	"can.offKeyValue": function(key, handler) {
+		var translationHandler;
 		if (isNaN(key)) {
-			this.removeEventListener(key, handler);
+			translationHandler = function(ev, newValue, oldValue) {
+				handler(newValue, oldValue);
+			};
+			this.removeEventListener(key, translationHandler);
 		}
 		else {
-			var translationHandler = singleReference.getAndDelete(handler, this, key);
+			translationHandler = singleReference.getAndDelete(handler, this, key);
 			this.removeEventListener('length', translationHandler);
 		}
 	},


### PR DESCRIPTION
Removed duplicate assign of `onKeyValue` and `offKeyValue` as well as set a translation handler for `NaN` keys to follow the `can-reflect` event api.

For #252 