### PR TITLE
Rolling back changes to fix failing can-connect tests

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -304,10 +304,7 @@ make = {
 					computeFn = defaultValue;
 					valueTrap = trapSets(computeFn);
 				} else {
-					computeFn = new Observation(boundGet, map, {
-						isObservable: false,
-						isProactivelyCacheable: true
-					});
+					computeFn = new Observation(boundGet, map);
 					valueTrap = trapSets(computeFn);
 					valueTrap.lastSetValue = defaultValue;
 				}
@@ -591,9 +588,6 @@ make = {
 		},
 		computed: function(prop) {
 			return function() {
-				if (!this.__inSetup) {
-					Observation.add(this, prop);
-				}
 				return canReflect.getValue(this._computed[prop].compute);
 			};
 		}

--- a/define-test.js
+++ b/define-test.js
@@ -5,7 +5,6 @@ var CanList = require("can-define/list/list");
 var canBatch = require("can-event/batch/batch");
 var each = require("can-util/js/each/each");
 var canSymbol = require("can-symbol");
-var Observation = require("can-observation");
 
 QUnit.module("can-define");
 
@@ -1356,59 +1355,6 @@ QUnit.test('defined properties are configurable', function(){
 
 	var a = new A();
 	QUnit.equal(a.val, "bar", "It was redefined");
-});
-
-function objectMock (obj, propertyKey, newValue) {
-	var oldValue = obj[propertyKey];
-	obj[propertyKey] = newValue;
-	return function unmock () {
-		obj[propertyKey] = oldValue;
-	};
-}
-
-QUnit.test('canReflect.onKeyValue should bind directly on the map for computed props (#149)', function (assert) {
-	/*
-	This test is making sure that the binding is placed on the
-	property key, not the property value.
-	*/
-	assert.expect(1);
-	var value = 1;
-	var externalCompute = compute(value);
-
-	var Person = function(first, last) {
-		this.first = first;
-		this.last = last;
-	};
-
-	define(Person.prototype, {
-		get foo () {
-			return externalCompute();
-		}
-	});
-
-	var map = new Person();
-	var onKeyValueKey = canSymbol.for('can.onKeyValue');
-	var unmockMap = objectMock(map, onKeyValueKey, function (key, handler) {
-		assert.equal(key, 'foo', 'should bind on the ' + key + ' property');
-	});
-
-	var proxyValue = compute(function () {
-		return map.foo;
-	});
-
-	var origAdd = Observation.add;
-	var unmockObservation = objectMock(Observation, 'add', function(obj, event) {
-		if (obj instanceof Observation) {
-			assert.ok(false, 'Observation.add should not be called on the internal observation');
-		}
-		origAdd.call(null, obj, event);
-	});
-
-	var subscription = function () {};
-	proxyValue.on('change', subscription);
-	proxyValue.off('change', subscription);
-	unmockMap();
-	unmockObservation();
 });
 
 QUnit.test('define() should add a CID (#246)', function() {


### PR DESCRIPTION
Tests were inconsistently failing for `can-connect` when all tests for CanJS were ran.

The breaking changes were introduced with this fix: https://github.com/canjs/can-define/pull/244

Discussion of the issue is here: https://github.com/canjs/can-define/issues/149

For: https://github.com/canjs/can-define/issues/149