### PR TITLE
Warn when setting a property that has only a zero-arg getter.

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -262,8 +262,9 @@ define.property = function(objPrototype, prop, definition, dataInitializers, com
 	// If there's zero-arg `get` but not `set`, warn on all sets in dev mode
 	else if (definition.get.length < 1) {
 		setter = function() {
-			dev.warn("Set value for property " +
+			dev.warn("can-define: Set value for property " +
 				prop +
+				(objPrototype.constructor.shortName ? " on " + objPrototype.constructor.shortName : "") +
 				" ignored, as its definition has a zero-argument getter and no setter");
 		};
 	}

--- a/can-define.js
+++ b/can-define.js
@@ -253,11 +253,21 @@ define.property = function(objPrototype, prop, definition, dataInitializers, com
 		// Add `set` functionality to the eventSetter.
 		setter = make.set.setter(prop, definition.set, reader, eventsSetter, false);
 	}
-	// If there's niether `set` or `get`,
+	// If there's neither `set` or `get`,
 	else if (!definition.get) {
 		// make a set that produces events.
 		setter = eventsSetter;
 	}
+	//!steal-remove-start
+	// If there's zero-arg `get` but not `set`, warn on all sets in dev mode
+	else if (definition.get.length < 1) {
+		setter = function() {
+			dev.warn("Set value for property " +
+				prop +
+				" ignored, as its definition has a zero-argument getter and no setter");
+		};
+	}
+	//!steal-remove-end
 
 	// Add type behavior to the setter.
 	if (type) {
@@ -326,6 +336,7 @@ make = {
 				handler: function(newVal) {
 					var oldValue = computeObj.oldValue;
 					computeObj.oldValue = newVal;
+
 					canEvent.dispatch.call(map, {
 						type: prop,
 						target: map,

--- a/define-test.js
+++ b/define-test.js
@@ -1426,7 +1426,9 @@ if(System.env.indexOf("production") < 0) {
 		define(VM.prototype, {
 		    currency: {
 		        type: Currency, // should be `Type: Currency`
-		        value: new Currency({})
+		        value: function() {
+		        	return new Currency({});
+		        }
 		    }
 		});
 
@@ -1439,7 +1441,9 @@ if(System.env.indexOf("production") < 0) {
 		define(VM2.prototype, {
 		    currency: {
 		        type: Currency, // should be `Type: Currency`
-		        value: new Currency({})
+		        value: function() {
+		        	return new Currency({});
+		        }
 		    }
 		});
 

--- a/define-test.js
+++ b/define-test.js
@@ -1372,7 +1372,7 @@ QUnit.test('define() should add a CID (#246)', function() {
 
 if(System.env.indexOf("production") < 0) {
 	QUnit.test('Setting a value with only a get() generates a warning (#202)', function() {
-		QUnit.expect(2);
+		QUnit.expect(3);
 		var VM = function() {};
 		define(VM.prototype, {
 			derivedProp: {
@@ -1389,12 +1389,22 @@ if(System.env.indexOf("production") < 0) {
 		canDev.warn = function(mesg) {
 			QUnit.equal(
 				mesg,
-				"Set value for property derivedProp ignored, as its definition has a zero-argument getter and no setter",
+				"can-define: Set value for property derivedProp ignored, as its definition has a zero-argument getter and no setter",
 				"Warning is expected message");
 		};
 
 		vm.derivedProp = 'prop is set';
 		QUnit.equal(vm.derivedProp, "Hello World", "Getter value is preserved");
+
+		VM.shortName = "VM";
+		canDev.warn = function(mesg) {
+			QUnit.equal(
+				mesg,
+				"can-define: Set value for property derivedProp on VM ignored, as its definition has a zero-argument getter and no setter",
+				"Warning is expected message");
+		};
+
+		vm.derivedProp = 'prop is set';
 		canDev.warn = oldwarn;
 	});
 }


### PR DESCRIPTION
If a property has a definition consisting of a zero arg getter and no setter, and the environment is not production, and the user attempts to set the property, this PR generates a warning.

Fixes #202 