### PR TITLE
Warn when a constructor is supplied as a type definition

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -182,6 +182,17 @@ define.property = function(objPrototype, prop, definition, dataInitializers, com
 
 	var type = definition.type;
 
+	//!steal-remove-start
+	if (type && canReflect.isConstructorLike(type)) {
+		dev.warn(
+			"can-define: the definition for " +
+			prop +
+			(objPrototype.constructor.shortName ? " on " + objPrototype.constructor.shortName : "") +
+			" uses a constructor for \"type\". Did you mean \"Type\"?"
+		);
+	}
+	//!steal-remove-end
+
 	// Special case definitions that have only `type: "*"`.
 	if (type && onlyType(definition) && type === define.types["*"]) {
 		Object.defineProperty(objPrototype, prop, {

--- a/define-test.js
+++ b/define-test.js
@@ -1370,40 +1370,44 @@ QUnit.test('define() should add a CID (#246)', function() {
 	QUnit.ok(g._cid, "should have a CID property");
 });
 
-QUnit.test("warn on using a Constructor for small-t type definintions", function() {
-	expect(2);
-	var oldWarn = canDev.warn;
-	canDev.warn = function(mesg) {
-		QUnit.equal(mesg, "can-define: the definition for currency uses a constructor for \"type\". Did you mean \"Type\"?");
-	};
+if (System.env.indexOf("production") < 0) {
 
-	function Currency() {
-		return this;
-	}
-	Currency.prototype = {
-		symbol: "USD"
-	};
+	QUnit.test("warn on using a Constructor for small-t type definintions", function() {
+		expect(2);
+		var oldWarn = canDev.warn;
+		canDev.warn = function(mesg) {
+			QUnit.equal(mesg, "can-define: the definition for currency uses a constructor for \"type\". Did you mean \"Type\"?");
+		};
 
-	function VM() {}
-	define(VM.prototype, {
-	    currency: {
-	        type: Currency, // should be `Type: Currency`
-	        value: new Currency({})
-	    }
+		function Currency() {
+			return this;
+		}
+		Currency.prototype = {
+			symbol: "USD"
+		};
+
+		function VM() {}
+		define(VM.prototype, {
+		    currency: {
+		        type: Currency, // should be `Type: Currency`
+		        value: new Currency({})
+		    }
+		});
+
+		canDev.warn = function(mesg) {
+			QUnit.equal(mesg, "can-define: the definition for currency on VM2 uses a constructor for \"type\". Did you mean \"Type\"?");
+		};
+
+		function VM2() {}
+		VM2.shortName = "VM2";
+		define(VM2.prototype, {
+		    currency: {
+		        type: Currency, // should be `Type: Currency`
+		        value: new Currency({})
+		    }
+		});
+
+		canDev.warn = oldWarn;
 	});
 
-	canDev.warn = function(mesg) {
-		QUnit.equal(mesg, "can-define: the definition for currency on VM2 uses a constructor for \"type\". Did you mean \"Type\"?");
-	};
-
-	function VM2() {}
-	VM2.shortName = "VM2";
-	define(VM2.prototype, {
-	    currency: {
-	        type: Currency, // should be `Type: Currency`
-	        value: new Currency({})
-	    }
-	});
-
-	canDev.warn = oldWarn;
-});
+}

--- a/define-test.js
+++ b/define-test.js
@@ -5,6 +5,7 @@ var CanList = require("can-define/list/list");
 var canBatch = require("can-event/batch/batch");
 var each = require("can-util/js/each/each");
 var canSymbol = require("can-symbol");
+var canDev = require("can-util/js/dev/dev");
 
 QUnit.module("can-define");
 
@@ -1367,4 +1368,42 @@ QUnit.test('define() should add a CID (#246)', function() {
 	});
 	var g = new Greeting();
 	QUnit.ok(g._cid, "should have a CID property");
+});
+
+QUnit.test("warn on using a Constructor for small-t type definintions", function() {
+	expect(2);
+	var oldWarn = canDev.warn;
+	canDev.warn = function(mesg) {
+		QUnit.equal(mesg, "can-define: the definition for currency uses a constructor for \"type\". Did you mean \"Type\"?");
+	};
+
+	function Currency() {
+		return this;
+	}
+	Currency.prototype = {
+		symbol: "USD"
+	};
+
+	function VM() {}
+	define(VM.prototype, {
+	    currency: {
+	        type: Currency, // should be `Type: Currency`
+	        value: new Currency({})
+	    }
+	});
+
+	canDev.warn = function(mesg) {
+		QUnit.equal(mesg, "can-define: the definition for currency on VM2 uses a constructor for \"type\". Did you mean \"Type\"?");
+	};
+
+	function VM2() {}
+	VM2.shortName = "VM2";
+	define(VM2.prototype, {
+	    currency: {
+	        type: Currency, // should be `Type: Currency`
+	        value: new Currency({})
+	    }
+	});
+
+	canDev.warn = oldWarn;
 });


### PR DESCRIPTION
In these cases, it's likely that a user meant to use a `Type` def rather than `type`; this uses `can-reflect.isConstructorLike` to determine if the supplied function or object is a constructor.

Fixes #205 

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
