### PR TITLE
Implement can.getName symbol behavior

### DIFF
--- a/list/list-test.js
+++ b/list/list-test.js
@@ -1185,24 +1185,6 @@ QUnit.test("updateDeep property", function() {
 	propEqual(list.get('foo'), undefined, 'Foo is set to undefined');
 });
 
-QUnit.test("registered symbols", function() {
-	var a = new DefineMap({ "a": "a" });
-
-	ok(a[canSymbol.for("can.isMapLike")], "can.isMapLike");
-	equal(a[canSymbol.for("can.getKeyValue")]("a"), "a", "can.getKeyValue");
-	a[canSymbol.for("can.setKeyValue")]("a", "b");
-	equal(a.a, "b", "can.setKeyValue");
-
-	function handler(val) {
-		equal(val, "c", "can.onKeyValue");
-	}
-
-	a[canSymbol.for("can.onKeyValue")]("a", handler);
-	a.a = "c";
-
-	a[canSymbol.for("can.offKeyValue")]("a", handler);
-	a.a = "d"; // doesn't trigger handler
-});
 
 QUnit.test("cannot remove length", function() {
 	var list = new DefineList(["a"]);
@@ -1272,4 +1254,21 @@ QUnit.test("iterator can recover from bad _length", function() {
 	var iterator = list[canSymbol.iterator]();
 	var iteration = iterator.next();
 	QUnit.ok(iteration.done, "Didn't fail");
+});
+
+QUnit.test("can.getName symbol behavior", function(assert) {
+	var getName = function(instance) {
+		return instance[canSymbol.for("can.getName")]();
+	};
+
+	assert.ok(
+		/DefineList\[\d+\]/.test(getName(new DefineList())),
+		"should use DefineList constructor name by default"
+	);
+
+	var MyList = DefineList.extend("MyList", {});
+	assert.ok(
+		/MyList\[\d+\]/.test(getName(new MyList())),
+		"should use custom list name when provided"
+	);
 });

--- a/list/list.js
+++ b/list/list.js
@@ -8,6 +8,7 @@ var canLog = require("can-util/js/log/log");
 var canDev = require("can-util/js/dev/dev");
 var defineHelpers = require("../define-helpers/define-helpers");
 
+var CID = require("can-cid");
 var assign = require("can-util/js/assign/assign");
 var diff = require("can-util/js/diff/diff");
 var each = require("can-util/js/each/each");
@@ -1512,7 +1513,7 @@ canReflect.assignSymbols(DefineList.prototype,{
 	"can.getKeyValue": DefineList.prototype.get,
 	"can.setKeyValue": DefineList.prototype.set,
 	"can.getName": function() {
-		return this.constructor.name + "[" + this._cid + "]";
+		return this.constructor.name + "[" + CID(this) + "]";
 	},
 
 	// Called for every reference to a property in a template

--- a/list/list.js
+++ b/list/list.js
@@ -1511,6 +1511,9 @@ canReflect.assignSymbols(DefineList.prototype,{
 	// get/set
 	"can.getKeyValue": DefineList.prototype.get,
 	"can.setKeyValue": DefineList.prototype.set,
+	"can.getName": function() {
+		return this.constructor.name + "[" + this._cid + "]";
+	},
 
 	// Called for every reference to a property in a template
 	// if a key is a numerical index then translate to length event

--- a/map/map.js
+++ b/map/map.js
@@ -11,6 +11,7 @@ var canSymbol = require("can-symbol");
 var CIDSet = require("can-util/js/cid-set/cid-set");
 var CIDMap = require("can-util/js/cid-map/cid-map");
 var canDev = require("can-util/js/dev/dev");
+var CID = require("can-cid");
 
 var keysForDefinition = function(definitions) {
 	var keys = [];
@@ -425,7 +426,7 @@ canReflect.assignSymbols(DefineMap.prototype,{
 		return this;
 	},
 	"can.getName": function() {
-		return this.constructor.name + "{" + this._cid + "}";
+		return this.constructor.name + "{" + CID(this) + "}";
 	},
 
 	// -shape

--- a/map/map.js
+++ b/map/map.js
@@ -424,6 +424,9 @@ canReflect.assignSymbols(DefineMap.prototype,{
 		this.set(prop, undefined);
 		return this;
 	},
+	"can.getName": function() {
+		return this.constructor.name + "{" + this._cid + "}";
+	},
 
 	// -shape
 	"can.getOwnEnumerableKeys": function(){

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "can-observation": "^3.3.4",
     "can-reflect": "^1.2.1",
     "can-simple-observable": "^1.0.0",
-    "can-symbol": "^1.0.0",
+    "can-symbol": "^1.3.0",
     "can-types": "^1.1.0",
     "can-util": "^3.9.0"
   },


### PR DESCRIPTION
Ref: https://github.com/canjs/can-symbol/issues/16

```js
// DefineMap
var Person = DefineMap.extend("Person", {});
var me = new Person();

me[canSymbol.for("can.getName")]() // "Person{1}"

// DefineList
var Things = DefineList.extend("Things", {});
var list = new Things([]);

list[canSymbol.for("can.getName")]() // "Things{2}"
```

