### PR TITLE
Add `.log` to log DefineMap and DefineList changes

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,7 +23,8 @@
 		"stop": true,
 		"global": true,
 		"event": true,
-		"define": true
+		"define": true,
+		"Set": true
 	},
 	"curly": true,
 	"eqeqeq": true,

--- a/ensure-meta.js
+++ b/ensure-meta.js
@@ -1,0 +1,15 @@
+var canSymbol = require("can-symbol");
+var canReflect = require("can-reflect");
+
+// Ensure the "obj" passed as an argument has an object on @@can.meta
+module.exports = function ensureMeta(obj) {
+	var metaSymbol = canSymbol.for("can.meta");
+	var meta = obj[metaSymbol];
+
+	if (!meta) {
+		meta = {};
+		canReflect.setKeyValue(obj, metaSymbol, meta);
+	}
+
+	return meta;
+};

--- a/list/list.js
+++ b/list/list.js
@@ -6,6 +6,8 @@ var Observation = require("can-observation");
 var canLog = require("can-util/js/log/log");
 var canDev = require("can-util/js/dev/dev");
 var defineHelpers = require("../define-helpers/define-helpers");
+var dev = require("can-log/dev/dev");
+var ensureMeta = require("../ensure-meta");
 
 var assign = require("can-util/js/assign/assign");
 var diff = require("can-util/js/diff/diff");
@@ -497,7 +499,8 @@ var DefineList = Construct.extend("DefineList",
 			var args = makeArray(arguments),
 				added = [],
 				i, len, listIndex,
-				allSame = args.length > 2;
+				allSame = args.length > 2,
+				oldLength = this._length;
 
 			index = index || 0;
 
@@ -536,7 +539,7 @@ var DefineList = Construct.extend("DefineList",
 				this._triggerChange("" + index, "add", added, removed);
 			}
 
-			this.dispatch('length', [ this._length ]);
+			this.dispatch('length', [ this._length, oldLength ]);
 
 			queues.batch.stop();
 			return removed;
@@ -568,8 +571,54 @@ var DefineList = Construct.extend("DefineList",
 		 */
 		serialize: function() {
 			return canReflect.serialize(this, CIDMap);
+		},
+
+		// call `list.log()` to log all event changes
+		// pass `key` to only log the matching event, e.g: `list.log("add")`
+		log: function(key) {
+			//!steal-remove-start
+			var instance = this;
+
+			var quoteString = function quoteString(x) {
+				return typeof x === "string" ? JSON.stringify(x) : x;
+			};
+
+			var meta = ensureMeta(instance);
+			var allowed = meta.allowedLogKeysSet || new Set();
+			meta.allowedLogKeysSet = allowed;
+
+			if (key) {
+				allowed.add(key);
+			}
+
+			meta._log = function(event, data) {
+				var type = event.type;
+
+				if (type === "can.onPatches" || (key && !allowed.has(type))) {
+					return;
+				}
+
+				if (type === "add" || type === "remove") {
+					dev.log(
+						canReflect.getName(instance),
+						"\n how   ", quoteString(type),
+						"\n what  ", quoteString(data[0]),
+						"\n index ", quoteString(data[1])
+					);
+				} else {
+					// log `length` and `propertyName` events
+					dev.log(
+						canReflect.getName(instance),
+						"\n key ", quoteString(type),
+						"\n is  ", quoteString(data[0]),
+						"\n was ", quoteString(data[1])
+					);
+				}
+			};
+			//!steal-remove-end
 		}
-	});
+	}
+);
 
 // Converts to an `array` of arguments.
 var getArgs = function(args) {
@@ -703,7 +752,7 @@ each({
 			if (!this.comparator || args.length) {
 				queues.batch.start();
 				this._triggerChange("" + len, "add", args, undefined);
-				this.dispatch('length', [ this._length ]);
+				this.dispatch('length', [ this._length, len ]);
 				queues.batch.stop();
 			}
 
@@ -798,6 +847,7 @@ each({
 
 			var args = getArgs(arguments),
 				len = where && this._length ? this._length - 1 : 0,
+				oldLength = this._length ? this._length : 0,
 				res;
 
 			// Call the original method.
@@ -812,7 +862,7 @@ each({
 			// `res` - The old, removed values (should these be unbound).
 			queues.batch.start();
 			this._triggerChange("" + len, "remove", undefined, [ res ]);
-			this.dispatch('length', [ this._length ]);
+			this.dispatch('length', [ this._length, oldLength ]);
 			queues.batch.stop();
 
 			return res;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "can-construct": "^3.2.0",
     "can-define-lazy-value": "^1.0.0",
     "can-event-queue": "<2.0.0",
+    "can-log": "^0.1.0",
     "can-namespace": "^1.0.0",
     "can-observation": "^4.0.0-pre.3",
     "can-observation-recorder": "<2.0.0",


### PR DESCRIPTION
 The `DefineMap` log output is the same as the one in `SimpleMap`, `DefineList` has a small variation though:

a) `propertyName` and `length` events use the labels `key`, `is`, and `was`
b) `add` and `remove` use the labels `how`, `what` and `index`.

![screen shot 2017-10-18 at 09 37 45](https://user-images.githubusercontent.com/724877/31728878-bd3c3d8c-b3ea-11e7-9148-567040331a47.png)
