### PR TITLE
Don't allow improper shorthand props on DefineMaps and throw error

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -11,7 +11,7 @@ var Observation = require("can-observation");
 
 var isEmptyObject = require("can-util/js/is-empty-object/is-empty-object");
 var assign = require("can-util/js/assign/assign");
-var canLog = require("can-log/dev/dev");
+var canLogDev = require("can-log/dev/dev");
 var CID = require("can-cid");
 var isPlainObject = require("can-util/js/is-plain-object/is-plain-object");
 var types = require("can-types");
@@ -185,7 +185,7 @@ define.property = function(objPrototype, prop, definition, dataInitializers, com
 
 	//!steal-remove-start
 	if (type && canReflect.isConstructorLike(type)) {
-		canLog.warn(
+		canLogDev.warn(
 			"can-define: the definition for " +
 			prop +
 			(objPrototype.constructor.shortName ? " on " + objPrototype.constructor.shortName : "") +
@@ -242,11 +242,11 @@ define.property = function(objPrototype, prop, definition, dataInitializers, com
 		//!steal-remove-start
 		// If value is an object or array, give a warning
 		if (definition.value !== null && typeof definition.value === 'object') {
-			canLog.warn("can-define: The value for " + prop + " is set to an object. This will be shared by all instances of the DefineMap. Use a function that returns the object instead.");
+			canLogDev.warn("can-define: The value for " + prop + " is set to an object. This will be shared by all instances of the DefineMap. Use a function that returns the object instead.");
 		}
 		// If value is a constructor, give a warning
 		if (definition.value && canReflect.isConstructorLike(definition.value)) {
-			canLog.warn("can-define: The \"value\" for " + prop + " is set to a constructor. Did you mean \"Value\" instead?");
+			canLogDev.warn("can-define: The \"value\" for " + prop + " is set to a constructor. Did you mean \"Value\" instead?");
 		}
 		//!steal-remove-end
 
@@ -286,7 +286,7 @@ define.property = function(objPrototype, prop, definition, dataInitializers, com
 	// If there's zero-arg `get` but not `set`, warn on all sets in dev mode
 	else if (definition.get.length < 1) {
 		setter = function() {
-			canLog.warn("can-define: Set value for property " +
+			canLogDev.warn("can-define: Set value for property " +
 				prop +
 				(objPrototype.constructor.shortName ? " on " + objPrototype.constructor.shortName : "") +
 				" ignored, as its definition has a zero-argument getter and no setter");
@@ -458,8 +458,8 @@ make = {
 						else {
 							//!steal-remove-start
 							asyncTimer = setTimeout(function() {
-								canLog.warn('can/map/setter.js: Setter "' + prop + '" did not return a value or call the setter callback.');
-							}, canLog.warnTimeout);
+								canLogDev.warn('can/map/setter.js: Setter "' + prop + '" did not return a value or call the setter callback.');
+							}, canLogDev.warnTimeout);
 							//!steal-remove-end
 							canBatch.stop();
 							return;
@@ -490,8 +490,8 @@ make = {
 						else {
 							//!steal-remove-start
 							asyncTimer = setTimeout(function() {
-								canLog.warn('can/map/setter.js: Setter "' + prop + '" did not return a value or call the setter callback.');
-							}, canLog.warnTimeout);
+								canLogDev.warn('can/map/setter.js: Setter "' + prop + '" did not return a value or call the setter callback.');
+							}, canLogDev.warnTimeout);
 							//!steal-remove-end
 							canBatch.stop();
 							return;
@@ -734,7 +734,7 @@ getDefinitionsAndMethods = function(defines, baseDefines) {
 			else {
 				// Removed adding raw values that are not types or Types
 				// methods[prop] = result;
-				canLog.error("A Constructor or string must be used with shorthand definitions: https://canjs.com/doc/can-define.types.propDefinition.html#String");
+				canLogDev.error("A Constructor or string must be used with shorthand definitions: https://canjs.com/doc/can-define.types.propDefinition.html#String");
 			}
 			//!steal-remove-end
 		}

--- a/can-define.js
+++ b/can-define.js
@@ -11,7 +11,7 @@ var Observation = require("can-observation");
 
 var isEmptyObject = require("can-util/js/is-empty-object/is-empty-object");
 var assign = require("can-util/js/assign/assign");
-var dev = require("can-util/js/dev/dev");
+var canLog = require("can-log/dev/dev");
 var CID = require("can-cid");
 var isPlainObject = require("can-util/js/is-plain-object/is-plain-object");
 var types = require("can-types");
@@ -185,7 +185,7 @@ define.property = function(objPrototype, prop, definition, dataInitializers, com
 
 	//!steal-remove-start
 	if (type && canReflect.isConstructorLike(type)) {
-		dev.warn(
+		canLog.warn(
 			"can-define: the definition for " +
 			prop +
 			(objPrototype.constructor.shortName ? " on " + objPrototype.constructor.shortName : "") +
@@ -242,11 +242,11 @@ define.property = function(objPrototype, prop, definition, dataInitializers, com
 		//!steal-remove-start
 		// If value is an object or array, give a warning
 		if (definition.value !== null && typeof definition.value === 'object') {
-			dev.warn("can-define: The value for " + prop + " is set to an object. This will be shared by all instances of the DefineMap. Use a function that returns the object instead.");
+			canLog.warn("can-define: The value for " + prop + " is set to an object. This will be shared by all instances of the DefineMap. Use a function that returns the object instead.");
 		}
 		// If value is a constructor, give a warning
 		if (definition.value && canReflect.isConstructorLike(definition.value)) {
-			dev.warn("can-define: The \"value\" for " + prop + " is set to a constructor. Did you mean \"Value\" instead?");
+			canLog.warn("can-define: The \"value\" for " + prop + " is set to a constructor. Did you mean \"Value\" instead?");
 		}
 		//!steal-remove-end
 
@@ -286,7 +286,7 @@ define.property = function(objPrototype, prop, definition, dataInitializers, com
 	// If there's zero-arg `get` but not `set`, warn on all sets in dev mode
 	else if (definition.get.length < 1) {
 		setter = function() {
-			dev.warn("can-define: Set value for property " +
+			canLog.warn("can-define: Set value for property " +
 				prop +
 				(objPrototype.constructor.shortName ? " on " + objPrototype.constructor.shortName : "") +
 				" ignored, as its definition has a zero-argument getter and no setter");
@@ -458,8 +458,8 @@ make = {
 						else {
 							//!steal-remove-start
 							asyncTimer = setTimeout(function() {
-								dev.warn('can/map/setter.js: Setter "' + prop + '" did not return a value or call the setter callback.');
-							}, dev.warnTimeout);
+								canLog.warn('can/map/setter.js: Setter "' + prop + '" did not return a value or call the setter callback.');
+							}, canLog.warnTimeout);
 							//!steal-remove-end
 							canBatch.stop();
 							return;
@@ -490,8 +490,8 @@ make = {
 						else {
 							//!steal-remove-start
 							asyncTimer = setTimeout(function() {
-								dev.warn('can/map/setter.js: Setter "' + prop + '" did not return a value or call the setter callback.');
-							}, dev.warnTimeout);
+								canLog.warn('can/map/setter.js: Setter "' + prop + '" did not return a value or call the setter callback.');
+							}, canLog.warnTimeout);
 							//!steal-remove-end
 							canBatch.stop();
 							return;
@@ -729,9 +729,14 @@ getDefinitionsAndMethods = function(defines, baseDefines) {
 			var result = getDefinitionOrMethod(prop, value, defaultDefinition);
 			if(result && typeof result === "object") {
 				definitions[prop] = result;
-			} else {
-				methods[prop] = result;
+			} 
+			//!steal-remove-start
+			else {
+				// Removed adding raw values that are not types or Types
+				// methods[prop] = result;
+				canLog.error("A Constructor or string must be used with shorthand definitions: https://canjs.com/doc/can-define.types.propDefinition.html#String");
 			}
+			//!steal-remove-end
 		}
 	});
 	if(defaults) {

--- a/can-define.js
+++ b/can-define.js
@@ -669,7 +669,7 @@ makeDefinition = function(prop, def, defaultDefinition) {
 	// if def.type is a string it is handled in addDefinition
 	if(typeof def.type !== 'string') {
 		// if there's no type definition, take it from the defaultDefinition
-		if(typeof def.type !== 'string' && !definition.type && !definition.Type) {
+		if(!definition.type && !definition.Type) {
 			defaults(definition, defaultDefinition);
 		}
 

--- a/can-define.js
+++ b/can-define.js
@@ -745,8 +745,7 @@ getDefinitionsAndMethods = function(defines, baseDefines) {
 				}
 				//!steal-remove-start
 				else if (typeof result !== 'undefined') {
-					var shortName = this.constructor.shortName ? this.constructor.shortName : "DefineMap";
-					canLogDev.error(prop + " on " + shortName + " does not match a supported propDefinition. See: https://canjs.com/doc/can-define.types.propDefinition.html");
+					canLogDev.error(prop + (this.constructor.shortName ? " on " + this.constructor.shortName : "") + " does not match a supported propDefinition. See: https://canjs.com/doc/can-define.types.propDefinition.html");
 				}
 				//!steal-remove-end
 			}

--- a/can-define.js
+++ b/can-define.js
@@ -745,7 +745,8 @@ getDefinitionsAndMethods = function(defines, baseDefines) {
 				}
 				//!steal-remove-start
 				else if (typeof result !== 'undefined') {
-					canLogDev.error(prop + " on " + this.constructor.shortName + " does not match a supported propDefinition. See: https://canjs.com/doc/can-define.types.propDefinition.html");
+					var shortName = this.constructor.shortName ? this.constructor.shortName : "DefineMap";
+					canLogDev.error(prop + " on " + shortName + " does not match a supported propDefinition. See: https://canjs.com/doc/can-define.types.propDefinition.html");
 				}
 				//!steal-remove-end
 			}

--- a/can-define.js
+++ b/can-define.js
@@ -41,7 +41,7 @@ var defineConfigurableAndNotEnumerable = function(obj, prop, value) {
 var eachPropertyDescriptor = function(map, cb){
 	for(var prop in map) {
 		if(map.hasOwnProperty(prop)) {
-			cb(prop, Object.getOwnPropertyDescriptor(map,prop));
+			cb.call(map, prop, Object.getOwnPropertyDescriptor(map,prop));
 		}
 	}
 };
@@ -745,7 +745,7 @@ getDefinitionsAndMethods = function(defines, baseDefines) {
 				}
 				//!steal-remove-start
 				else if (typeof result !== 'undefined') {
-					canLogDev.error("A Constructor or string must be used with shorthand definitions: https://canjs.com/doc/can-define.types.propDefinition.html#String");
+					canLogDev.error(prop + " on " + this.constructor.shortName + " does not match a supported propDefinition. See: https://canjs.com/doc/can-define.types.propDefinition.html");
 				}
 				//!steal-remove-end
 			}

--- a/define-test.js
+++ b/define-test.js
@@ -581,7 +581,6 @@ test('Can make an attr alias a compute (#1470)', 9, function() {
 	var GetMap = define.Constructor({
 		value: {
 			set: function(newValue, setVal, oldValue) {
-				//debugger;
 				if (newValue.isComputed) {
 					return newValue;
 				}

--- a/define-test.js
+++ b/define-test.js
@@ -5,7 +5,7 @@ var CanList = require("can-define/list/list");
 var canBatch = require("can-event/batch/batch");
 var each = require("can-util/js/each/each");
 var canSymbol = require("can-symbol");
-var canDev = require("can-util/js/dev/dev");
+var testHelpers = require("can-test-helpers");
 
 QUnit.module("can-define");
 
@@ -1369,84 +1369,82 @@ QUnit.test('define() should add a CID (#246)', function() {
 	QUnit.ok(g._cid, "should have a CID property");
 });
 
-if(System.env.indexOf("production") < 0) {
-	QUnit.test('Setting a value with only a get() generates a warning (#202)', function() {
-		QUnit.expect(3);
-		var VM = function() {};
-		define(VM.prototype, {
-			derivedProp: {
-				get: function() {
-					return "Hello World";
-				}
+testHelpers.dev.devOnlyTest("Setting a value with only a get() generates a warning (#202)", function() {
+	QUnit.expect(7);
+
+	var message = "can-define: Set value for property derivedProp ignored, as its definition has a zero-argument getter and no setter";
+	var finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
+		QUnit.equal(actualMessage, message, "Warning is expected message");
+		QUnit.ok(success);
+	});
+
+	var VM = function() {};
+	define(VM.prototype, {
+		derivedProp: {
+			get: function() {
+				return "Hello World";
 			}
-		});
-
-		var vm = new VM();
-		vm.on("derivedProp", function() {});
-
-		var oldwarn = canDev.warn;
-		canDev.warn = function(mesg) {
-			QUnit.equal(
-				mesg,
-				"can-define: Set value for property derivedProp ignored, as its definition has a zero-argument getter and no setter",
-				"Warning is expected message");
-		};
-
-		vm.derivedProp = 'prop is set';
-		QUnit.equal(vm.derivedProp, "Hello World", "Getter value is preserved");
-
-		VM.shortName = "VM";
-		canDev.warn = function(mesg) {
-			QUnit.equal(
-				mesg,
-				"can-define: Set value for property derivedProp on VM ignored, as its definition has a zero-argument getter and no setter",
-				"Warning is expected message");
-		};
-
-		vm.derivedProp = 'prop is set';
-		canDev.warn = oldwarn;
-	});
-
-	QUnit.test("warn on using a Constructor for small-t type definintions", function() {
-		expect(2);
-		var oldWarn = canDev.warn;
-		canDev.warn = function(mesg) {
-			QUnit.equal(mesg, "can-define: the definition for currency uses a constructor for \"type\". Did you mean \"Type\"?");
-		};
-
-		function Currency() {
-			return this;
 		}
-		Currency.prototype = {
-			symbol: "USD"
-		};
-
-		function VM() {}
-		define(VM.prototype, {
-		    currency: {
-		        type: Currency, // should be `Type: Currency`
-		        value: function() {
-		        	return new Currency({});
-		        }
-		    }
-		});
-
-		canDev.warn = function(mesg) {
-			QUnit.equal(mesg, "can-define: the definition for currency on VM2 uses a constructor for \"type\". Did you mean \"Type\"?");
-		};
-
-		function VM2() {}
-		VM2.shortName = "VM2";
-		define(VM2.prototype, {
-		    currency: {
-		        type: Currency, // should be `Type: Currency`
-		        value: function() {
-		        	return new Currency({});
-		        }
-		    }
-		});
-
-		canDev.warn = oldWarn;
 	});
 
-}
+	var vm = new VM();
+	vm.on("derivedProp", function() {});
+
+	vm.derivedProp = 'prop is set';
+	QUnit.equal(vm.derivedProp, "Hello World", "Getter value is preserved");
+
+	VM.shortName = "VM";
+
+	QUnit.equal(finishErrorCheck(), 1);
+
+	message = "can-define: Set value for property derivedProp on VM ignored, as its definition has a zero-argument getter and no setter";
+	finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
+		QUnit.equal(actualMessage, message, "Warning is expected message");
+		QUnit.ok(success);
+	});
+
+	vm.derivedProp = 'prop is set';
+	QUnit.equal(finishErrorCheck(), 1);
+});
+
+testHelpers.dev.devOnlyTest("warn on using a Constructor for small-t type definintions", function() {
+	QUnit.expect(2);
+
+	var message = "can-define: the definition for currency uses a constructor for \"type\". Did you mean \"Type\"?";
+	var finishErrorCheck = testHelpers.dev.willWarn(message);
+
+	function Currency() {
+		return this;
+	}
+	Currency.prototype = {
+		symbol: "USD"
+	};
+
+	function VM() {}
+	define(VM.prototype, {
+		currency: {
+			type: Currency, // should be `Type: Currency`
+			value: function() {
+				return new Currency({});
+			}
+		}
+	});
+
+	QUnit.equal(finishErrorCheck(), 1);
+
+	message = "can-define: the definition for currency on VM2 uses a constructor for \"type\". Did you mean \"Type\"?";
+	finishErrorCheck = testHelpers.dev.willWarn(message);
+
+	function VM2() {}
+	VM2.shortName = "VM2";
+	define(VM2.prototype, {
+		currency: {
+			type: Currency, // should be `Type: Currency`
+			value: function() {
+				return new Currency({});
+			}
+		}
+	});
+
+	QUnit.equal(finishErrorCheck(), 1);
+});

--- a/docs/types.propDefinition.md
+++ b/docs/types.propDefinition.md
@@ -145,7 +145,7 @@ propertyName: function() {}
 
 For example:
 ```js
-subMap: DefineMap // <- calls constructor
+subMap: DefineMap // <- sets Type to DefineMap
 ```
 OR
 ```js

--- a/docs/types.propDefinition.md
+++ b/docs/types.propDefinition.md
@@ -133,11 +133,23 @@ propertyName: {
 propertyName: "typeName"
 ```
 
-@type {Constructor} Defines a [can-define.types.TypeConstructor Type] setting with a constructor
-function.  Constructor functions are identified with [can-util/js/types/types.isConstructor].
+@type {Constructor} Either creates a method or Defines a [can-define.types.TypeConstructor Type] setting with a constructor function.  Constructor functions are identified with [can-reflect.isConstructorLike].
 
 ```
 propertyName: Constructor
+```
+OR
+```
+propertyName: function() {}
+```
+
+For example:
+```js
+subMap: DefineMap // <- calls constructor
+```
+OR
+```js
+increment: function() { ++this.count } // <- sets method prop
 ```
 
 @type {Array} Defines an inline [can-define/list/list] Type setting. This is

--- a/list/list.js
+++ b/list/list.js
@@ -4,8 +4,8 @@ var make = define.make;
 var canEvent = require("can-event");
 var canBatch = require("can-event/batch/batch");
 var Observation = require("can-observation");
-var canLog = require("can-util/js/log/log");
-var canDev = require("can-util/js/dev/dev");
+var canLog = require("can-log");
+var canLogDev = require("can-log/dev/dev");
 var defineHelpers = require("../define-helpers/define-helpers");
 
 var assign = require("can-util/js/assign/assign");
@@ -272,7 +272,7 @@ var DefineList = Construct.extend("DefineList",
 			// otherwise we are setting multiple
 			else {
 				//!steal-remove-start
-				canDev.warn('can-define/list/list.prototype.set is deprecated; please use can-define/list/list.prototype.assign or can-define/list/list.prototype.update instead');
+				canLogDev.warn('can-define/list/list.prototype.set is deprecated; please use can-define/list/list.prototype.assign or can-define/list/list.prototype.update instead');
 				//!steal-remove-end
 
 				//we are deprecating this in #245

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -9,7 +9,6 @@ var compute = require("can-compute");
 var assign = require("can-util/js/assign/assign");
 var canReflect = require("can-reflect");
 var isPlainObject = require("can-util/js/is-plain-object/is-plain-object");
-var canDev = require("can-util/js/dev/dev");
 var testHelpers = require('can-test-helpers');
 
 var sealWorks = (function() {
@@ -888,59 +887,57 @@ QUnit.test('Observation bound to async getter updates correctly (canjs#3541)', f
 
 });
 
-if(System.env.indexOf("production") < 0) {
-	QUnit.test('Setting a value with an object type generates a warning (#148)', function() {
-		QUnit.expect(2);
-		var oldwarn = canDev.warn;
-		canDev.warn = function(mesg) {
-			QUnit.equal(mesg, "can-define: The value for options is set to an object. This will be shared by all instances of the DefineMap. Use a function that returns the object instead.");
-		};
-		//should issue a warning
-		DefineMap.extend({
-			options: {
-				value: {}
-			}
-		});
-		//should issue a warning
-		DefineMap.extend({
-			options: {
-				value: []
-			}
-		});
+testHelpers.dev.devOnlyTest("Setting a value with an object type generates a warning (#148)", function() {
+	QUnit.expect(1);
 
-		//should not issue a warning
-		DefineMap.extend({
-			options: {
-				value: function(){}
-			}
-		});
+	var message = "can-define: The value for options is set to an object. This will be shared by all instances of the DefineMap. Use a function that returns the object instead.";
+	var finishErrorCheck = testHelpers.dev.willWarn(message);
 
-		//should not issue a warning
-		DefineMap.extend({
-			options: {
-				value: 2
-			}
-		});
-		canDev.warn = oldwarn;
+	//should issue a warning
+	DefineMap.extend({
+		options: {
+			value: {}
+		}
 	});
-	QUnit.test('Setting a value to a constructor type generates a warning', function() {
-		QUnit.expect(1);
-		var oldwarn = canDev.warn;
-		canDev.warn = function(mesg) {
-			QUnit.equal(mesg, "can-define: The \"value\" for options is set to a constructor. Did you mean \"Value\" instead?");
-		};
-
-		//should issue a warning
-		DefineMap.extend({
-			options: {
-				value: DefineMap
-			}
-		});
-
-		canDev.warn = oldwarn;
+	//should issue a warning
+	DefineMap.extend({
+		options: {
+			value: []
+		}
 	});
 
-}
+	//should not issue a warning
+	DefineMap.extend({
+		options: {
+			value: function(){}
+		}
+	});
+
+	//should not issue a warning
+	DefineMap.extend({
+		options: {
+			value: 2
+		}
+	});
+
+	QUnit.equal(finishErrorCheck(), 2);
+});
+
+testHelpers.dev.devOnlyTest("Setting a value to a constructor type generates a warning", function() {
+	QUnit.expect(1);
+
+	var message = "can-define: The \"value\" for options is set to a constructor. Did you mean \"Value\" instead?";
+	var finishErrorCheck = testHelpers.dev.willWarn(message);
+
+	//should issue a warning
+	DefineMap.extend({
+		options: {
+			value: DefineMap
+		}
+	});
+
+	QUnit.equal(finishErrorCheck(), 1);
+});
 
 QUnit.test('Assign value on map', function() {
 	var MyConstruct = DefineMap.extend({

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -10,6 +10,7 @@ var assign = require("can-util/js/assign/assign");
 var canReflect = require("can-reflect");
 var isPlainObject = require("can-util/js/is-plain-object/is-plain-object");
 var canDev = require("can-util/js/dev/dev");
+var testHelpers = require('can-test-helpers');
 
 var sealWorks = (function() {
 	try {
@@ -1043,4 +1044,38 @@ QUnit.test('Deep updating a map', function() {
 	QUnit.equal(obj.name, undefined, 'Name property has been reset');
 	QUnit.equal(obj.list[0], 'something', 'the first element of the list should be updated');
 
+});
+
+testHelpers.dev.devOnlyTest("Error on not using a constructor or string on short-hand definitions (#278)", function() {
+	expect(1);
+	var message = "A Constructor or string must be used with shorthand definitions: https://canjs.com/doc/can-define.types.propDefinition.html#String";
+	var finishErrorCheck = testHelpers.dev.willError(message);
+
+	// Having JSHint ignore this because we don't need to actually
+	// use 'VM' anywhere to get the errors to show and the test to complete
+	/* jshint ignore:start */
+	var VM = DefineMap.extend({
+		prop01: 0,
+		prop02: function() {},
+		prop03: 'string',
+		prop04: DefineMap,
+		// prop05: [],
+		get prop06() {},
+		set prop06(newVal) {}
+	});
+	/* jshint ignore:end */
+
+	QUnit.equal(finishErrorCheck(), 2);
+});
+
+QUnit.test('Improper shorthand properties are not set', function() {
+	var VM = DefineMap.extend({
+		prop01: 0,
+		prop02: function() {},
+		prop03: 'some random string'
+	});
+
+	QUnit.equal(VM.prototype._define.methods.prop01, undefined);
+	QUnit.equal(VM.prototype._define.methods.prop02, undefined);
+	QUnit.equal(VM.prototype._define.methods.prop03, undefined);
 });

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1044,14 +1044,16 @@ QUnit.test('Deep updating a map', function() {
 });
 
 testHelpers.dev.devOnlyTest("Error on not using a constructor or string on short-hand definitions (#278)", function() {
-	expect(1);
-	var message = "A Constructor or string must be used with shorthand definitions: https://canjs.com/doc/can-define.types.propDefinition.html#String";
-	var finishErrorCheck = testHelpers.dev.willError(message);
+	expect(5);
+	var message = /.+ on .+ does not match a supported propDefinition. See: https:\/\/canjs.com\/doc\/can-define.types.propDefinition.html/i;
 
-	// Having JSHint ignore this because we don't need to actually
-	// use 'VM' anywhere to get the errors to show and the test to complete
-	/* jshint ignore:start */
-	var VM = DefineMap.extend({
+	var finishErrorCheck = testHelpers.dev.willError(message, function(actual, match) {
+		var rightProp = /prop0[15]/;
+		QUnit.ok(rightProp.test(actual.slice(0, 6)));
+		QUnit.ok(match);
+	});
+
+	DefineMap.extend('ShortName', {
 		prop01: 0,
 		prop02: function() {},
 		prop03: 'string',
@@ -1062,7 +1064,6 @@ testHelpers.dev.devOnlyTest("Error on not using a constructor or string on short
 		set prop07(newVal) {},
 		prop08: 'boolean'
 	});
-	/* jshint ignore:end */
 
 	QUnit.equal(finishErrorCheck(), 2);
 });

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1056,9 +1056,11 @@ testHelpers.dev.devOnlyTest("Error on not using a constructor or string on short
 		prop02: function() {},
 		prop03: 'string',
 		prop04: DefineMap,
-		// prop05: [],
-		get prop06() {},
-		set prop06(newVal) {}
+		prop05: "a string that is not a type",
+		prop06: [],
+		get prop07() {},
+		set prop07(newVal) {},
+		prop08: 'boolean'
 	});
 	/* jshint ignore:end */
 
@@ -1073,6 +1075,6 @@ QUnit.test('Improper shorthand properties are not set', function() {
 	});
 
 	QUnit.equal(VM.prototype._define.methods.prop01, undefined);
-	QUnit.equal(VM.prototype._define.methods.prop02, undefined);
+	QUnit.equal(typeof VM.prototype._define.methods.prop02, 'function');
 	QUnit.equal(VM.prototype._define.methods.prop03, undefined);
 });

--- a/map/map.js
+++ b/map/map.js
@@ -5,12 +5,12 @@ var Observation = require("can-observation");
 var types = require("can-types");
 var canBatch = require("can-event/batch/batch");
 var ns = require("can-namespace");
-var canLog = require("can-util/js/log/log");
+var canLog = require("can-log");
+var canLogDev = require("can-log/dev/dev");
 var canReflect = require("can-reflect");
 var canSymbol = require("can-symbol");
 var CIDSet = require("can-util/js/cid-set/cid-set");
 var CIDMap = require("can-util/js/cid-map/cid-map");
-var canDev = require("can-util/js/dev/dev");
 
 var keysForDefinition = function(definitions) {
 	var keys = [];
@@ -184,7 +184,7 @@ var DefineMap = Construct.extend("DefineMap",{
 	set: function(prop, value){
 		if(typeof prop === "object") {
 			//!steal-remove-start
-			canDev.warn('can-define/map/map.prototype.set is deprecated; please use can-define/map/map.prototype.assign or can-define/map/map.prototype.update instead');
+			canLogDev.warn('can-define/map/map.prototype.set is deprecated; please use can-define/map/map.prototype.assign or can-define/map/map.prototype.update instead');
 			//!steal-remove-end
 			if(value === true) {
 				updateDeep.call(this, prop);

--- a/package.json
+++ b/package.json
@@ -37,11 +37,13 @@
     "can-construct": "^3.2.0",
     "can-define-lazy-value": "^1.0.0",
     "can-event": "^3.5.0",
+    "can-log": "^0.1.0",
     "can-namespace": "^1.0.0",
     "can-observation": "^3.3.4",
     "can-reflect": "^1.2.1",
     "can-simple-observable": "^1.0.0",
     "can-symbol": "^1.0.0",
+    "can-test-helpers": "^1.1.0",
     "can-types": "^1.1.0",
     "can-util": "^3.9.0"
   },


### PR DESCRIPTION
We want to show an error in development anytime someone tries to use shorthand syntax for a `DefineMap` prop and furthermore, don't assign it.

For instance if someone does:
```js
var ViewModel = DefineMap.extend({
  someProp: 'this is some random string and not a type',
  someOtherProp: function() {} // <- This is not a Constructor function
});
```
We should ignore both of these cases and throw the error.

The only values allowed with the shorthand can be found here: https://canjs.com/doc/can-define.types.propDefinition.html

Closes https://github.com/canjs/can-define/issues/278