### PR TITLE
preventing events from being dispatched when setting a property that uses resolver

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -320,13 +320,13 @@ define.property = function(objPrototype, prop, definition, dataInitializers, com
 		// Add `set` functionality to the eventSetter.
 		setter = make.set.setter(prop, definition.set, reader, eventsSetter, false);
 	}
-	// If there's neither `set` or `get`,
-	else if (!definition.get) {
+	// If there's neither `set` or `get` or `value` (resolver)
+	else if (dataProperty === "data") {
 		// make a set that produces events.
 		setter = eventsSetter;
 	}
 	// If there's zero-arg `get` but not `set`, warn on all sets in dev mode
-	else if (definition.get.length < 1) {
+	else if (definition.get && definition.get.length < 1) {
 		setter = function() {
 			//!steal-remove-start
 			canLogDev.warn("can-define: Set value for property " +

--- a/test/test-value-resolve.js
+++ b/test/test-value-resolve.js
@@ -238,6 +238,33 @@ QUnit.test("location vm with setter", function(){
 
 });
 
+QUnit.test("events should not be fired when resolve is not called", function(){
+	var Numbers = DefineMap.extend("Numbers",{
+		oddNumber: {
+			value: function(prop) {
+				prop.resolve(5);
+
+				prop.listenTo(prop.lastSet, function(newVal){
+					if (newVal % 2) {
+						prop.resolve(newVal);
+					}
+				});
+			}
+		}
+	});
+
+	var nums = new Numbers({});
+
+	QUnit.equal(nums.oddNumber, 5, "initial value is 5");
+
+	nums.on("oddNumber", function(ev, newVal){
+		QUnit.equal(newVal % 2, 1, "event dispatched for " + newVal);
+	});
+
+	nums.oddNumber = 7;
+	nums.oddNumber = 8;
+});
+
 /*
 QUnit.test("fullName getter/setter the hard way", 3, function(){
     var Person = DefineMap.extend("Person", {


### PR DESCRIPTION
closes https://github.com/canjs/can-define/issues/318.