### PR TITLE
Add methods for creating observables to/from properties

### DIFF
--- a/map/docs/prototype.valueBind.md
+++ b/map/docs/prototype.valueBind.md
@@ -1,0 +1,30 @@
+@function can-define/map/map.prototype.valueBind valueBind
+@parent can-define/map/map.prototype
+
+@description Get an observable for getting and setting a property on a map.
+
+@signature `map.valueBind( propName )`
+
+  @param {String} propName The property for which you’d like an observable.
+
+  @return {Object} An observable compatible with [can-reflect]’s
+  [can-reflect.getValue] and [can-reflect.setValue] methods.
+
+@body
+
+## Use
+
+```js
+import canReflect from "can-reflect";
+import DefineMap from "can-define/map/map";
+
+const map = new DefineMap({
+	greeting: "hello"
+});
+
+const greetingObservable = map.valueBind("greeting");
+// canReflect.getValue(greetingObservable) === "hello"
+
+canReflect.setValue(greetingObservable, "aloha");
+// firstMap.prop === "aloha"
+```

--- a/map/docs/prototype.valueFrom.md
+++ b/map/docs/prototype.valueFrom.md
@@ -1,0 +1,30 @@
+@function can-define/map/map.prototype.valueFrom valueFrom
+@parent can-define/map/map.prototype
+
+@description Get an observable for getting (but not setting) a property on a map.
+
+@signature `map.valueFrom( propName )`
+
+  @param {String} propName The property for which you’d like an observable.
+
+  @return {Object} An observable compatible with [can-reflect.getValue can-reflect.getValue()]
+  but not [can-reflect.setValue can-reflect.setValue()].
+
+@body
+
+## Use
+
+```js
+import canReflect from "can-reflect";
+import DefineMap from "can-define/map/map";
+
+const map = new DefineMap({
+	greeting: "hello"
+});
+
+const greetingObservable = map.valueFrom("greeting");
+// canReflect.getValue(greetingObservable) === "hello"
+
+canReflect.setValue(greetingObservable, "aloha");
+// Error thrown because the value isn’t settable
+```

--- a/map/docs/prototype.valueTo.md
+++ b/map/docs/prototype.valueTo.md
@@ -1,0 +1,30 @@
+@function can-define/map/map.prototype.valueTo valueTo
+@parent can-define/map/map.prototype
+
+@description Get an observable for setting (but not getting) a property on a map.
+
+@signature `map.valueTo( propName )`
+
+  @param {String} propName The property for which you’d like an observable.
+
+  @return {Object} An observable compatible with [can-reflect.setValue can-reflect.setValue()]
+  but not [can-reflect.getValue can-reflect.getValue()].
+
+@body
+
+## Use
+
+```js
+import canReflect from "can-reflect";
+import DefineMap from "can-define/map/map";
+
+const map = new DefineMap({
+	greeting: "hello"
+});
+
+const greetingObservable = map.valueTo("greeting");
+// canReflect.getValue(greetingObservable) returns undefined
+
+canReflect.setValue(greetingObservable, "aloha");
+// firstMap.prop === "aloha"
+```

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1204,3 +1204,50 @@ QUnit.test("value as a string breaks", function(){
 	var my = new MyMap();
 	QUnit.equal(my.prop, "a string", "works");
 });
+
+QUnit.test("valueBind method works", function() {
+	var firstMap = new DefineMap({
+		prop: "hello"
+	});
+	var getAndSetProp = firstMap.valueBind("prop");
+
+	// Test getting the value
+	QUnit.equal(canReflect.getValue(getAndSetProp), "hello", "getting works");
+
+	// Test setting the value
+	canReflect.setValue(getAndSetProp, "aloha");
+	QUnit.equal(firstMap.prop, "aloha", "setting works");
+});
+
+QUnit.test("valueFrom method works", function() {
+	var firstMap = new DefineMap({
+		prop: "hello"
+	});
+	var getProp = firstMap.valueFrom("prop");
+
+	// Test getting the value
+	QUnit.equal(canReflect.getValue(getProp), "hello", "getting works");
+
+	// Setting the value shouldn’t work
+	var errorThrown;
+	try {
+		canReflect.setValue(getProp, "aloha");
+	} catch (error) {
+		errorThrown = true;
+	}
+	QUnit.ok(errorThrown, "setting doesn’t work");
+});
+
+QUnit.test("valueTo method works", function() {
+	var firstMap = new DefineMap({
+		prop: "hello"
+	});
+	var setProp = firstMap.valueTo("prop");
+
+	// Getting the value shouldn’t work
+	QUnit.equal(canReflect.getValue(setProp), undefined, "getting doesn’t work");
+
+	// Test setting the value
+	canReflect.setValue(setProp, "aloha");
+	QUnit.equal(firstMap.prop, "aloha", "setting works");
+});

--- a/map/map.js
+++ b/map/map.js
@@ -3,6 +3,7 @@ var Construct = require("can-construct");
 var define = require("can-define");
 var defineHelpers = require("../define-helpers/define-helpers");
 var ObservationRecorder = require("can-observation-recorder");
+var SetterObservable = require("can-simple-observable/setter/setter");
 var ns = require("can-namespace");
 var canLog = require("can-log");
 var canLogDev = require("can-log/dev/dev");
@@ -412,6 +413,28 @@ var DefineMap = Construct.extend("DefineMap",{
 	})(),
 	"*": {
 		type: define.types.observable
+	},
+
+	valueBind: function(prop) {
+		return new SetterObservable(function() {
+			return this.get(prop);
+		}.bind(this), function(newValue) {
+			this.set(prop, newValue);
+		}.bind(this));
+	},
+
+	valueFrom: function(prop) {
+		return new SetterObservable(function() {
+			return this.get(prop);
+		}.bind(this));
+	},
+
+	valueTo: function(prop) {
+		return new SetterObservable(function() {
+			// This line intentionally left blank :)
+		}, function(newValue) {
+			this.set(prop, newValue);
+		}.bind(this));
 	},
 
 	// call `map.log()` to log all event changes


### PR DESCRIPTION
This adds `valueBind`, `valueFrom`, and `valueTo` methods for getting observables that can replicate one-way and two-way bindings with DefineMap objects.

The docs below are not great, so some suggestions for improving them would be greatly appreciated.

I’m also not 100% sold on the method names; I do like that they have the same prefix, but `valueFrom` sounds like it would be getting a value and the other two don’t really indicate what they do or return. I haven’t been able to think of any worthwhile alternatives though that either aren’t too long or don’t share a common prefix.

<details>
<summary>valueBind</summary>
<img width="548" alt="valuebind" src="https://user-images.githubusercontent.com/10070176/38284199-dfb78648-376e-11e8-9ee7-6596e182a37c.png">
</details>

<details>
<summary>valueFrom</summary>
<img width="549" alt="valuefrom" src="https://user-images.githubusercontent.com/10070176/38284198-df8b9588-376e-11e8-9ec6-429c3c17834d.png">
</details>

<details>
<summary>valueTo</summary>
<img width="550" alt="valueto" src="https://user-images.githubusercontent.com/10070176/38284197-df710b14-376e-11e8-9ecf-0eebb50f7191.png">
</details>