### PR TITLE
exposes a schema

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -1116,3 +1116,20 @@ define.types = {
 		}
 	}
 };
+
+define.updateSchemaKeys = function(schema, definitions) {
+	for(var prop in definitions) {
+		var definition = definitions[prop];
+
+		if(definition.type) {
+			schema.keys[prop] = definition.type;
+		} else {
+			schema.keys[prop] = function(val){ return val; };
+		}
+		 // some unknown type
+		if(definitions[prop].identity === true) {
+			schema.identity.push(prop);
+		}
+	}
+	return schema;
+};

--- a/list/list-test.js
+++ b/list/list-test.js
@@ -1455,3 +1455,18 @@ QUnit.test(".sort() produces patches (can-stache#498)", function(){
 
 	QUnit.deepEqual(calledPatches, PATCHES);
 });
+
+QUnit.test("canReflect.getSchema", function(){
+	var MyType = DefineMap.extend({
+		id: {identity: true, type: "number"},
+		name: "string"
+	});
+	var MyList = DefineList.extend({
+		count: "number",
+		"#": MyType
+	});
+
+	var schema = canReflect.getSchema(MyList);
+
+	QUnit.equal(schema.values, MyType);
+});

--- a/list/list.js
+++ b/list/list.js
@@ -43,6 +43,23 @@ var makeFilterCallback = function(props) {
 
 var onKeyValue = define.eventsProto[canSymbol.for("can.onKeyValue")];
 var offKeyValue = define.eventsProto[canSymbol.for("can.offKeyValue")];
+var getSchemaSymbol = canSymbol.for("can.getSchema");
+
+function getSchema() {
+	var definitions = this.prototype._define.definitions;
+	var schema = {
+		type: "list",
+		keys: {}
+	};
+	schema = define.updateSchemaKeys(schema, definitions);
+	if(schema.keys["#"]) {
+		schema.values = definitions["#"].Type;
+		delete schema.keys["#"];
+	}
+
+	return schema;
+}
+
 
 /** @add can-define/list/list */
 var DefineList = Construct.extend("DefineList",
@@ -64,6 +81,7 @@ var DefineList = Construct.extend("DefineList",
 						this.prototype.__type = make.set.type("*", itemsDefinition.type, identity);
 					}
 				}
+				this[getSchemaSymbol] = getSchema;
 			}
 		}
 	},

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1204,3 +1204,19 @@ QUnit.test("value as a string breaks", function(){
 	var my = new MyMap();
 	QUnit.equal(my.prop, "a string", "works");
 });
+
+QUnit.test("canReflect.getSchema", function(){
+	var MyType = DefineMap.extend({
+		id: {identity: true, type: "number"},
+		name: "string"
+	});
+
+	var schema = canReflect.getSchema(MyType);
+
+	QUnit.deepEqual(schema.identity, ["id"], "right identity");
+	QUnit.deepEqual(Object.keys(schema.keys), ["id","name"], "right key names");
+
+	QUnit.equal( canReflect.convert("1", schema.keys.id), 1, "converted to number");
+
+	QUnit.equal( canReflect.convert(3, schema.keys.id), "3", "converted to number");
+});

--- a/map/map.js
+++ b/map/map.js
@@ -61,6 +61,19 @@ function getKeyValue(key) {
 		return this[key];
 	}
 }
+
+var getSchemaSymbol = canSymbol.for("can.getSchema");
+
+function getSchema() {
+	var definitions = this.prototype._define.definitions;
+	var schema = {
+		type: "map",
+		identity: [],
+		keys: {}
+	};
+	return define.updateSchemaKeys(schema, definitions);
+}
+
 var DefineMap = Construct.extend("DefineMap",{
 	setup: function(base){
 		var key,
@@ -88,6 +101,7 @@ var DefineMap = Construct.extend("DefineMap",{
 			}
 		}
 		define.defineConfigurableAndNotEnumerable(prototype, "constructor", this);
+		this[getSchemaSymbol] = getSchema;
 	}
 },{
 	// setup for only dynamic DefineMap instances


### PR DESCRIPTION
This gives can-define the ability to expose a schema that can-query-logic can understand