### PR TITLE
Updating deprecation warning for .set to be more clear

### DIFF
--- a/map/map.js
+++ b/map/map.js
@@ -173,7 +173,7 @@ var DefineMap = Construct.extend("DefineMap",{
 	 * @function can-define/map/map.prototype.set set
 	 * @parent can-define/map/map.prototype
 	 *
-	 * @deprecated {3.10.1} Using .set with {Object} `props` has been deprecated in favour of `assign` and `update`
+	 * @deprecated {3.10.1} Passing an {Object} to `.set` has been deprecated in favor of [can-define/map/map.prototype.assign] or [can-define/map/map.prototype.update]. `map.set(propName, value)` is _not_ deprecated.
 	 *
 	 * @description Sets multiple properties on a map instance or a property that wasn't predefined.
 	 *


### PR DESCRIPTION
People often think that all signatures of`.set` are deprecated. Here is what the deprecation warning looks like now:

![image](https://user-images.githubusercontent.com/5851984/38682537-f2aa13d8-3e30-11e8-81f4-696723094820.png)
