### PR TITLE
fix warning messages for default values

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -291,11 +291,11 @@ define.property = function(objPrototype, prop, definition, dataInitializers, com
 		//!steal-remove-start
 		// If value is an object or array, give a warning
 		if (definition.default !== null && typeof definition.default === 'object') {
-			canLogDev.warn("can-define: The value for " + prop + " is set to an object. This will be shared by all instances of the DefineMap. Use a function that returns the object instead.");
+			canLogDev.warn("can-define: The default value for " + prop + " is set to an object. This will be shared by all instances of the DefineMap. Use a function that returns the object instead.");
 		}
 		// If value is a constructor, give a warning
 		if (definition.default && canReflect.isConstructorLike(definition.default)) {
-			canLogDev.warn("can-define: The \"value\" for " + prop + " is set to a constructor. Did you mean \"Value\" instead?");
+			canLogDev.warn("can-define: The \"default\" for " + prop + " is set to a constructor. Did you mean \"Default\" instead?");
 		}
 		//!steal-remove-end
 

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -980,7 +980,7 @@ canTestHelpers.devOnlyTest("log multiple property changes", function(assert) {
 canTestHelpers.devOnlyTest("Setting a value with an object type generates a warning (#148)", function() {
 	QUnit.expect(1);
 
-	var message = "can-define: The value for options is set to an object. This will be shared by all instances of the DefineMap. Use a function that returns the object instead.";
+	var message = "can-define: The default value for options is set to an object. This will be shared by all instances of the DefineMap. Use a function that returns the object instead.";
 	var finishErrorCheck = canTestHelpers.willWarn(message);
 
 	//should issue a warning
@@ -1013,10 +1013,10 @@ canTestHelpers.devOnlyTest("Setting a value with an object type generates a warn
 	QUnit.equal(finishErrorCheck(), 2);
 });
 
-canTestHelpers.devOnlyTest("Setting a value to a constructor type generates a warning", function() {
+canTestHelpers.devOnlyTest("Setting a default value to a constructor type generates a warning", function() {
 	QUnit.expect(1);
 
-	var message = "can-define: The \"value\" for options is set to a constructor. Did you mean \"Value\" instead?";
+	var message = "can-define: The \"default\" for options is set to a constructor. Did you mean \"Default\" instead?";
 	var finishErrorCheck = canTestHelpers.willWarn(message);
 
 	//should issue a warning


### PR DESCRIPTION
This fixes warning messages for default values to use 'default/Default' keywords instead of 'value/Value'

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
