### PR TITLE
removing can-util and using can-data-types

### DIFF
--- a/list/list-test.js
+++ b/list/list-test.js
@@ -9,7 +9,7 @@ var canSymbol = require("can-symbol");
 var dev = require("can-log/dev/dev");
 var canTestHelpers = require("can-test-helpers/lib/dev");
 
-var assign = require("can-util/js/assign/assign");
+var assign = require("can-assign");
 
 QUnit.module("can-define/list/list");
 

--- a/list/list.js
+++ b/list/list.js
@@ -11,14 +11,12 @@ var defineHelpers = require("../define-helpers/define-helpers");
 var dev = require("can-log/dev/dev");
 var ensureMeta = require("../ensure-meta");
 
-var assign = require("can-util/js/assign/assign");
-var diff = require("can-util/js/diff/diff");
-var each = require("can-util/js/each/each");
-var makeArray = require("can-util/js/make-array/make-array");
+var assign = require("can-assign");
+var diff = require("can-diff/list/list");
 var ns = require("can-namespace");
 var canReflect = require("can-reflect");
 var canSymbol = require("can-symbol");
-var singleReference = require("can-util/js/single-reference/single-reference");
+var singleReference = require("can-single-reference");
 
 var splice = [].splice;
 var runningNative = false;
@@ -511,7 +509,7 @@ var DefineList = Construct.extend("DefineList",
 		 *
 		 */
 		splice: function(index, howMany) {
-			var args = makeArray(arguments),
+			var args = canReflect.toArray(arguments),
 				added = [],
 				i, len, listIndex,
 				allSame = args.length > 2,
@@ -659,10 +657,10 @@ eventsProtoSymbols.forEach(function(sym) {
 var getArgs = function(args) {
 	return args[0] && Array.isArray(args[0]) ?
 		args[0] :
-		makeArray(args);
+		canReflect.toArray(args);
 };
 // Create `push`, `pop`, `shift`, and `unshift`
-each({
+canReflect.eachKey({
 		/**
 		 * @function can-define/list/list.prototype.push push
 		 * @description Add elements to the end of a list.
@@ -795,7 +793,7 @@ each({
 		};
 	});
 
-each({
+canReflect.eachKey({
 		/**
 		 * @function can-define/list/list.prototype.pop pop
 		 * @description Remove an element from the end of a DefineList.
@@ -904,7 +902,7 @@ each({
 		};
 	});
 
-each({
+canReflect.eachKey({
 	/**
 	 * @function can-define/list/list.prototype.map map
 	 * @description Map the values in this list to another list.
@@ -1379,11 +1377,11 @@ assign(DefineList.prototype, {
 		var args = [];
 		// Go through each of the passed `arguments` and
 		// see if it is list-like, an array, or something else
-		each(arguments, function(arg) {
+		canReflect.eachIndex(arguments, function(arg) {
 			if (canReflect.isListLike(arg)) {
 				// If it is list-like we want convert to a JS array then
 				// pass each item of the array to this.__type
-				var arr = Array.isArray(arg) ? arg : makeArray(arg);
+				var arr = Array.isArray(arg) ? arg : canReflect.toArray(arg);
 				arr.forEach(function(innerArg) {
 					args.push(this.__type(innerArg));
 				}, this);
@@ -1398,7 +1396,7 @@ assign(DefineList.prototype, {
 		// as well (We know it should be list-like), then
 		// concat with our passed in args, then pass it to
 		// list constructor to make it back into a list
-		return new this.constructor(Array.prototype.concat.apply(makeArray(this), args));
+		return new this.constructor(Array.prototype.concat.apply(canReflect.toArray(this), args));
 	},
 
 	/**

--- a/map/docs/define-map.md
+++ b/map/docs/define-map.md
@@ -225,7 +225,7 @@ view-models.  For example, a `view-model` might take a `todoId` value, and want
 to make a `todo` property available:
 
 ```js
-import ajax from "can-util/dom/ajax/ajax";
+import ajax from "can-ajax";
 
 const TodoViewModel = DefineMap.extend( {
 	todoId: "number",

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -2,11 +2,10 @@ var QUnit = require("steal-qunit");
 var DefineMap = require("can-define/map/map");
 var define = require("can-define");
 var Observation = require("can-observation");
-var each = require("can-util/js/each/each");
-var assign = require("can-util/js/assign/assign");
+var assign = require("can-assign");
 var canReflect = require("can-reflect");
 var canSymbol = require("can-symbol");
-var isPlainObject = require("can-util/js/is-plain-object/is-plain-object");
+var isPlainObject = canReflect.isPlainObject;
 var canTestHelpers = require("can-test-helpers/lib/dev");
 var DefineList = require("can-define/list/list");
 var dev = require("can-log/dev/dev");
@@ -312,7 +311,7 @@ QUnit.test("Properties are enumerable", function(){
   var vm = new VM({ foo: "bar", baz: "qux" });
 
   var i = 0;
-  each(vm, function(value, key){
+  canReflect.eachKey(vm, function(value, key){
 	if(i === 0) {
 	  QUnit.equal(key, "foo");
 	  QUnit.equal(value, "bar");
@@ -338,7 +337,7 @@ QUnit.test("Getters are not enumerable", function(){
 
   var map = new MyMap({ foo: "bar" });
 
-  each(map, function(value, key){
+  canReflect.eachKey(map, function(value, key){
 	QUnit.equal(key, "foo");
 	QUnit.equal(value, "bar");
   });

--- a/map/map.js
+++ b/map/map.js
@@ -65,7 +65,8 @@ function getKeyValue(key) {
 var getSchemaSymbol = canSymbol.for("can.getSchema");
 
 function getSchema() {
-	var definitions = this.prototype._define.definitions;
+	var def = this.prototype._define;
+	var definitions = def ? def.definitions : {};
 	var schema = {
 		type: "map",
 		identity: [],

--- a/package.json
+++ b/package.json
@@ -30,8 +30,11 @@
   },
   "homepage": "https://github.com/canjs/can-define",
   "dependencies": {
+    "can-assign": "^1.1.1",
     "can-construct": "^3.2.0",
+    "can-data-types": "<2.0.0",
     "can-define-lazy-value": "^1.0.0",
+    "can-diff": "^1.0.0",
     "can-event-queue": "^1.0.0",
     "can-log": "^1.0.0",
     "can-namespace": "^1.0.0",
@@ -40,8 +43,9 @@
     "can-queues": "^1.0.0",
     "can-reflect": "^1.7.0",
     "can-simple-observable": "^2.0.0",
-    "can-symbol": "^1.0.0",
-    "can-util": "^3.9.0"
+    "can-single-reference": "^1.0.0",
+    "can-string-to-any": "^1.0.1",
+    "can-symbol": "^1.0.0"
   },
   "devDependencies": {
     "can-reflect-tests": "<2.0.0",

--- a/test/test-define-only.js
+++ b/test/test-define-only.js
@@ -2,10 +2,10 @@ var QUnit = require("steal-qunit");
 
 var define = require("can-define");
 var queues = require("can-queues");
-var each = require("can-util/js/each/each");
 var canSymbol = require("can-symbol");
 var SimpleObservable = require("can-simple-observable");
 var testHelpers = require("can-test-helpers");
+var canReflect = require("can-reflect");
 
 QUnit.module("can-define");
 
@@ -936,7 +936,7 @@ QUnit.test('Extensions can modify definitions', function() {
 
 
 QUnit.test("Properties are enumerable", function() {
-	QUnit.expect(4);
+	QUnit.expect(1);
 
 	function VM(foo) {
 		this.foo = foo;
@@ -949,17 +949,16 @@ QUnit.test("Properties are enumerable", function() {
 	var vm = new VM("bar");
 	vm.baz = "qux";
 
-	var i = 0;
-	each(vm, function(value, key) {
-		if (i === 0) {
-			QUnit.equal(key, "foo");
-			QUnit.equal(value, "bar");
-		} else {
-			QUnit.equal(key, "baz");
-			QUnit.equal(value, "qux");
-		}
-		i++;
+	var copy = {};
+	for(var key in vm) {
+		copy[key] = vm[key];
+
+	}
+	QUnit.deepEqual(copy,{
+		foo: "bar",
+		baz: "qux"
 	});
+
 });
 
 QUnit.test("Doesn't override canSymbol.iterator if already on the prototype", function() {
@@ -992,9 +991,8 @@ QUnit.test("Doesn't override canSymbol.iterator if already on the prototype", fu
 	var map = new MyMap();
 	map.foo = "bar";
 
-	each(map, function(value, key) {
-		QUnit.equal(value, "worked");
-		QUnit.equal(key, "it");
+	canReflect.eachIndex(map, function(value) {
+		QUnit.deepEqual(value, ["it","worked"]);
 	});
 });
 

--- a/test/test-list-and-map.js
+++ b/test/test-list-and-map.js
@@ -1,8 +1,9 @@
 var DefineMap = require("can-define/map/map");
 var DefineList = require("can-define/list/list");
-var isPlainObject = require("can-util/js/is-plain-object/is-plain-object");
-var Observation = require("can-observation");
 var canReflect = require("can-reflect");
+var isPlainObject = canReflect.isPlainObject;
+var Observation = require("can-observation");
+
 var define = require("can-define");
 
 var QUnit = require("steal-qunit");


### PR DESCRIPTION
This removes can-util as a dependency and uses `can-data-types` for the maybe types