### PR TITLE
Normalize val: Type, val: { Type: Type } and val: { type: Type }

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -778,6 +778,23 @@ makeDefinition = function(prop, def, defaultDefinition) {
 			}
 		}
 	});
+
+	// normalize Type that implements can.new
+	if(def.Type) {
+		var value = def.Type;
+
+		var serialize = value[serializeSymbol];
+		if(serialize) {
+			definition.serialize = function(val){
+				return serialize.call(val);
+			};
+		}
+		if(value[newSymbol]) {
+			definition.type = value[newSymbol];
+			delete definition.Type;
+		}
+	}
+
 	// We only want to add a defaultDefinition if def.type is not a string
 	// if def.type is a string it is handled in addDefinition
 	if(typeof def.type !== 'string') {
@@ -807,16 +824,7 @@ getDefinitionOrMethod = function(prop, value, defaultDefinition){
 	}
     // copies a `Type`'s methods over
 	else if(value && (value[serializeSymbol] || value[newSymbol]) ) {
-		definition = {};
-		var serialize = value[serializeSymbol];
-		if(serialize) {
-			definition.serialize = function(val){
-				return serialize.call(val);
-			};
-		}
-		if(value[newSymbol]) {
-			definition.type = value[newSymbol];
-		}
+		definition = { Type: value };
 	}
 	else if(typeof value === "function") {
 		if(canReflect.isConstructorLike(value)) {

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1328,3 +1328,49 @@ QUnit.test("make sure stringOrObservable works", function(){
 
 	QUnit.equal(type.val, "foo", "works");
 });
+
+QUnit.test("primitive types work with val: Type", function(){
+	var UpperCase = {};
+	UpperCase[canSymbol.for("can.new")] = function(val){
+		return val.toUpperCase();
+	};
+
+	var Type = DefineMap.extend({
+		val: UpperCase
+	});
+
+	var type = new Type({ val: "works" });
+	QUnit.equal(type.val, "WORKS", "it worked");
+});
+
+QUnit.test("primitive types work with val: {Type: Type}", function(){
+	var UpperCase = {};
+	UpperCase[canSymbol.for("can.new")] = function(val){
+		return val.toUpperCase();
+	};
+
+	var Type = DefineMap.extend({
+		val: {
+			Type: UpperCase
+		}
+	});
+
+	var type = new Type({ val: "works" });
+	QUnit.equal(type.val, "WORKS", "it worked");
+});
+
+QUnit.test("primitive types work with val: {type: Type}", function(){
+	var UpperCase = {};
+	UpperCase[canSymbol.for("can.new")] = function(val){
+		return val.toUpperCase();
+	};
+
+	var Type = DefineMap.extend({
+		val: {
+			type: UpperCase
+		}
+	});
+
+	var type = new Type({ val: "works" });
+	QUnit.equal(type.val, "WORKS", "it worked");
+});


### PR DESCRIPTION
Makes this work with types that implement `canSymbol.for("can.new")`.