### PR TITLE
Make canReflect.getOwnKeys work on basic maps

### DIFF
--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1374,3 +1374,10 @@ QUnit.test("primitive types work with val: {type: Type}", function(){
 	var type = new Type({ val: "works" });
 	QUnit.equal(type.val, "WORKS", "it worked");
 });
+
+QUnit.test("ownKeys works on basic DefineMaps", function(){
+	var map = new DefineMap({ first: "Jane", last: "Doe" });
+	var keys = canReflect.getOwnKeys(map);
+
+	QUnit.equal(keys.length, 2, "There are 2 keys");
+});

--- a/map/map.js
+++ b/map/map.js
@@ -480,13 +480,15 @@ canReflect.assignSymbols(DefineMap.prototype,{
 	// -shape
 	"can.getOwnKeys": function() {
 		var keys = canReflect.getOwnEnumerableKeys(this);
-		var computedKeys = canReflect.getOwnKeys(this._computed);
+		if(this._computed) {
+			var computedKeys = canReflect.getOwnKeys(this._computed);
 
-		var key;
-		for (var i=0; i<computedKeys.length; i++) {
-			key = computedKeys[i];
-			if (keys.indexOf(key) < 0) {
-				keys.push(key);
+			var key;
+			for (var i=0; i<computedKeys.length; i++) {
+				key = computedKeys[i];
+				if (keys.indexOf(key) < 0) {
+					keys.push(key);
+				}
 			}
 		}
 


### PR DESCRIPTION
When a DefineMap doesn't have any computed properties, currently it is
throwing. This fixes it.