### PR TITLE
Fixes #353. Can-define special-keys assignment does not throw an error

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -54,7 +54,11 @@ if(process.env.NODE_ENV !== 'production') {
 				value:  "set "+canReflect.getName(obj) + "."+prop
 			});
 		}
-		return Object.defineProperty(obj, prop, definition);
+    var desc = Object.getOwnPropertyDescriptor(obj, prop);
+    if(!desc || desc.writable !== false){
+      return Object.defineProperty(obj, prop, definition);
+    }
+		return obj;
 	};
 }
 //!steal-remove-end

--- a/can-define.js
+++ b/can-define.js
@@ -54,10 +54,10 @@ if(process.env.NODE_ENV !== 'production') {
 				value:  "set "+canReflect.getName(obj) + "."+prop
 			});
 		}
-    var desc = Object.getOwnPropertyDescriptor(obj, prop);
-    if(!desc || desc.writable !== false){
-      return Object.defineProperty(obj, prop, definition);
-    }
+		var desc = Object.getOwnPropertyDescriptor(obj, prop);
+		if(desc === undefined || desc.writable !== false){
+			return Object.defineProperty(obj, prop, definition);
+		}
 		return obj;
 	};
 }

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -473,18 +473,15 @@ QUnit.test("copying with assign() excludes special keys", function() {
 
 	var a = {
 		_data: {},
-		constructor: function() {},
-		__bindEvents: {},
 		"foo": "bar",
-		"existing": "newVal"
+		"existing": "neVal"
 	};
 
 	var b = new DefineMap({
 		"existing": "oldVal"
 	});
-	assign(b, a);
+	canReflect.assignMap(b, a);
 
-	QUnit.notEqual(a.constructor, b.constructor, "Constructor prop not copied");
 	QUnit.notEqual(a._data, b._data, "_data prop not copied");
 	QUnit.equal(a.foo, b.foo, "New props copied");
 	QUnit.equal(a.existing, b.existing, "Existing props copied");


### PR DESCRIPTION
can-define/map/map-test.js was throwing an error when testing assignment of special keys to a DefineMap object. Added check to see if property being assigned is writable; if not, the property is skipped.

Should we add a warning if someone attempts to add a special key to a DefineMap object?

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
