### PR TITLE
Makes warnings show the constructor type name along with the property name

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -77,7 +77,7 @@ function eachPropertyDescriptor(map, cb){
 	}
 }
 
-function cleanUpDefinition(prop, definition, shouldWarn){
+function cleanUpDefinition(prop, definition, shouldWarn, typePrototype){
 	// cleanup `value` -> `default`
 	if(definition.value !== undefined && ( typeof definition.value !== "function" || definition.value.length === 0) ){
 
@@ -85,7 +85,7 @@ function cleanUpDefinition(prop, definition, shouldWarn){
 		if(process.env.NODE_ENV !== 'production') {
 			if(shouldWarn) {
 				canLogDev.warn(
-					"can-define: Change the 'value' definition for " + prop + " to 'default'."
+					"can-define: Change the 'value' definition for " + canReflect.getName(typePrototype)+"."+prop + " to 'default'."
 				);
 			}
 		}
@@ -100,7 +100,7 @@ function cleanUpDefinition(prop, definition, shouldWarn){
 		if(process.env.NODE_ENV !== 'production') {
 			if(shouldWarn) {
 				canLogDev.warn(
-					"can-define: Change the 'Value' definition for " + prop + " to 'Default'."
+					"can-define: Change the 'Value' definition for " + canReflect.getName(typePrototype)+"."+prop + " to 'Default'."
 				);
 			}
 		}
@@ -122,7 +122,7 @@ module.exports = define = ns.define = function(typePrototype, defines, baseDefin
 		// computed property definitions on _computed
 		computedInitializers = Object.create(baseDefine ? baseDefine.computedInitializers : null);
 
-	var result = getDefinitionsAndMethods(defines, baseDefine);
+	var result = getDefinitionsAndMethods(defines, baseDefine, typePrototype);
 	result.dataInitializers = dataInitializers;
 	result.computedInitializers = computedInitializers;
 
@@ -215,7 +215,7 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 	var propertyDefinition = define.extensions.apply(this, arguments);
 
 	if (propertyDefinition) {
-		definition = makeDefinition(prop, propertyDefinition, defaultDefinition || {});
+		definition = makeDefinition(prop, propertyDefinition, defaultDefinition || {}, typePrototype);
 	}
 
 	var type = definition.type;
@@ -224,9 +224,8 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 	if(process.env.NODE_ENV !== 'production') {
 		if (type && canReflect.isConstructorLike(type) && !isDefineType(type)) {
 			canLogDev.warn(
-				"can-define: the definition for " +
-				prop +
-				(typePrototype.constructor.shortName ? " on " + typePrototype.constructor.shortName : "") +
+				"can-define: the definition for " + canReflect.getName(typePrototype) + "."+
+                prop +
 				" uses a constructor for \"type\". Did you mean \"Type\"?"
 			);
 		}
@@ -303,11 +302,11 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 		if (process.env.NODE_ENV !== 'production') {
 			// If value is an object or array, give a warning
 			if (definition.default !== null && typeof definition.default === 'object') {
-				canLogDev.warn("can-define: The default value for " + prop + " is set to an object. This will be shared by all instances of the DefineMap. Use a function that returns the object instead.");
+				canLogDev.warn("can-define: The default value for " + canReflect.getName(typePrototype)+"."+prop + " is set to an object. This will be shared by all instances of the DefineMap. Use a function that returns the object instead.");
 			}
 			// If value is a constructor, give a warning
 			if (definition.default && canReflect.isConstructorLike(definition.default)) {
-				canLogDev.warn("can-define: The \"default\" for " + prop + " is set to a constructor. Did you mean \"Default\" instead?");
+				canLogDev.warn("can-define: The \"default\" for " + canReflect.getName(typePrototype)+"."+prop + " is set to a constructor. Did you mean \"Default\" instead?");
 			}
 		}
 		//!steal-remove-end
@@ -350,8 +349,7 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 			//!steal-remove-start
 			if(process.env.NODE_ENV !== 'production') {
 				canLogDev.warn("can-define: Set value for property " +
-					prop +
-					(typePrototype.constructor.shortName ? " on " + typePrototype.constructor.shortName : "") +
+					canReflect.getName(typePrototype)+"."+ prop +
 					" ignored, as its definition has a zero-argument getter and no setter");
 			}
 			//!steal-remove-end
@@ -380,9 +378,9 @@ define.makeDefineInstanceKey = function(constructor) {
 		var defineResult = this.prototype._define;
 		if(typeof value === "object") {
 			// change `value` to default.
-			cleanUpDefinition(property, value, false);
+			cleanUpDefinition(property, value, false, this);
 		}
-		var definition = getDefinitionOrMethod(property, value, defineResult.defaultDefinition);
+		var definition = getDefinitionOrMethod(property, value, defineResult.defaultDefinition, this);
 		if(definition && typeof definition === "object") {
 			define.property(constructor.prototype, property, definition, defineResult.dataInitializers, defineResult.computedInitializers, defineResult.defaultDefinition);
 			defineResult.definitions[property] = definition;
@@ -394,7 +392,7 @@ define.makeDefineInstanceKey = function(constructor) {
 
 // Makes a simple constructor function.
 define.Constructor = function(defines, sealed) {
-	var constructor = function(props) {
+	var constructor = function DefineConstructor(props) {
 		Object.defineProperty(this,"__inSetup",{
 			configurable: true,
 			enumerable: false,
@@ -571,7 +569,7 @@ make = {
 							//!steal-remove-start
 							if(process.env.NODE_ENV !== 'production') {
 								asyncTimer = setTimeout(function() {
-									canLogDev.warn('can/map/setter.js: Setter "' + prop + '" did not return a value or call the setter callback.');
+									canLogDev.warn('can-define: Setter "' + canReflect.getName(self)+"."+prop + '" did not return a value or call the setter callback.');
 								}, canLogDev.warnTimeout);
 							}
 							//!steal-remove-end
@@ -605,7 +603,7 @@ make = {
 							//!steal-remove-start
 							if(process.env.NODE_ENV !== 'production') {
 								asyncTimer = setTimeout(function() {
-									canLogDev.warn('can/map/setter.js: Setter "' + prop + '" did not return a value or call the setter callback.');
+									canLogDev.warn('can/map/setter.js: Setter "' + canReflect.getName(self)+"."+prop + '" did not return a value or call the setter callback.');
 								}, canLogDev.warnTimeout);
 							}
 							//!steal-remove-end
@@ -794,7 +792,7 @@ var addBehaviorToDefinition = function(definition, behavior, value) {
 // This is called by `define.property` AND `getDefinitionOrMethod` (which is called by `define`)
 // Currently, this is adding default behavior
 // copying `type` over, and even cleaning up the final definition object
-makeDefinition = function(prop, def, defaultDefinition) {
+makeDefinition = function(prop, def, defaultDefinition, typePrototype) {
 	var definition = {};
 
 	canReflect.eachKey(def, function(value, behavior) {
@@ -838,7 +836,7 @@ makeDefinition = function(prop, def, defaultDefinition) {
 			definition.type = define.types["*"];
 		}
 	}
-	cleanUpDefinition(prop, definition, true);
+	cleanUpDefinition(prop, definition, true, typePrototype);
 	return definition;
 };
 
@@ -846,7 +844,7 @@ makeDefinition = function(prop, def, defaultDefinition) {
 // returns the value or the definition object.
 // calls makeDefinition
 // This is dealing with a string value
-getDefinitionOrMethod = function(prop, value, defaultDefinition){
+getDefinitionOrMethod = function(prop, value, defaultDefinition, typePrototype){
 	// Clean up the value to make it a definition-like object
 	var definition;
 	if(typeof value === "string") {
@@ -868,14 +866,14 @@ getDefinitionOrMethod = function(prop, value, defaultDefinition){
 	}
 
 	if(definition) {
-		return makeDefinition(prop, definition, defaultDefinition);
+		return makeDefinition(prop, definition, defaultDefinition, typePrototype);
 	}
 	else {
 		return value;
 	}
 };
 // called by can.define
-getDefinitionsAndMethods = function(defines, baseDefines) {
+getDefinitionsAndMethods = function(defines, baseDefines, typePrototype) {
 	// make it so the definitions include base definitions on the proto
 	var definitions = Object.create(baseDefines ? baseDefines.definitions : null);
 	var methods = {};
@@ -902,7 +900,7 @@ getDefinitionsAndMethods = function(defines, baseDefines) {
 			methods[prop] = value;
 			return;
 		} else {
-			var result = getDefinitionOrMethod(prop, value, defaultDefinition);
+			var result = getDefinitionOrMethod(prop, value, defaultDefinition, typePrototype);
 			if(result && typeof result === "object" && canReflect.size(result) > 0) {
 				definitions[prop] = result;
 			}
@@ -915,7 +913,7 @@ getDefinitionsAndMethods = function(defines, baseDefines) {
 				else if (typeof result !== 'undefined') {
 					if(process.env.NODE_ENV !== 'production') {
                     	// Ex: {prop: 0}
-						canLogDev.error(prop + (this.constructor.shortName ? " on " + this.constructor.shortName : "") + " does not match a supported propDefinition. See: https://canjs.com/doc/can-define.types.propDefinition.html");
+						canLogDev.error(canReflect.getName(typePrototype)+"."+prop + " does not match a supported propDefinition. See: https://canjs.com/doc/can-define.types.propDefinition.html");
 					}
 				}
 				//!steal-remove-end

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -979,7 +979,7 @@ canTestHelpers.devOnlyTest("log multiple property changes", function(assert) {
 canTestHelpers.devOnlyTest("Setting a value with an object type generates a warning (#148)", function() {
 	QUnit.expect(1);
 
-	var message = "can-define: The default value for options is set to an object. This will be shared by all instances of the DefineMap. Use a function that returns the object instead.";
+	var message = "can-define: The default value for DefineMap{}.options is set to an object. This will be shared by all instances of the DefineMap. Use a function that returns the object instead.";
 	var finishErrorCheck = canTestHelpers.willWarn(message);
 
 	//should issue a warning
@@ -1015,7 +1015,7 @@ canTestHelpers.devOnlyTest("Setting a value with an object type generates a warn
 canTestHelpers.devOnlyTest("Setting a default value to a constructor type generates a warning", function() {
 	QUnit.expect(1);
 
-	var message = "can-define: The \"default\" for options is set to a constructor. Did you mean \"Default\" instead?";
+	var message = "can-define: The \"default\" for DefineMap{}.options is set to a constructor. Did you mean \"Default\" instead?";
 	var finishErrorCheck = canTestHelpers.willWarn(message);
 
 	//should issue a warning
@@ -1048,11 +1048,11 @@ canTestHelpers.devOnlyTest("can.getName symbol behavior", function(assert) {
 
 canTestHelpers.devOnlyTest("Error on not using a constructor or string on short-hand definitions (#278)", function() {
 	expect(5);
-	var message = /.+ on .+ does not match a supported propDefinition. See: https:\/\/canjs.com\/doc\/can-define.types.propDefinition.html/i;
+	var message = /does not match a supported propDefinition. See: https:\/\/canjs.com\/doc\/can-define.types.propDefinition.html/i;
 
 	var finishErrorCheck = canTestHelpers.willError(message, function(actual, match) {
 		var rightProp = /prop0[15]/;
-		QUnit.ok(rightProp.test(actual.slice(0, 6)));
+		QUnit.ok(rightProp.test(actual.split(" ")[0]));
 		QUnit.ok(match);
 	});
 

--- a/test/test-define-only.js
+++ b/test/test-define-only.js
@@ -1180,8 +1180,9 @@ testHelpers.dev.devOnlyTest("Setting a value with only a get() generates a warni
 
 	var VM = function() {};
 
-	var message = "can-define: Set value for property "+canReflect.getName(VM)+".derivedProp ignored, as its definition has a zero-argument getter and no setter";
+	var message = "can-define: Set value for property "+canReflect.getName(VM.prototype)+".derivedProp ignored, as its definition has a zero-argument getter and no setter";
 	var finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
+
 		QUnit.equal(actualMessage, message, "Warning is expected message");
 		QUnit.ok(success);
 	});
@@ -1205,7 +1206,7 @@ testHelpers.dev.devOnlyTest("Setting a value with only a get() generates a warni
 
 	QUnit.equal(finishErrorCheck(), 1);
 
-	message = "can-define: Set value for property "+canReflect.getName(VM)+"{}.derivedProp ignored, as its definition has a zero-argument getter and no setter";
+	message = "can-define: Set value for property "+canReflect.getName(VM.prototype)+".derivedProp ignored, as its definition has a zero-argument getter and no setter";
 	finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
 		QUnit.equal(actualMessage, message, "Warning is expected message");
 		QUnit.ok(success);

--- a/test/test-define-only.js
+++ b/test/test-define-only.js
@@ -1178,7 +1178,7 @@ QUnit.test('defined properties are configurable', function(){
 testHelpers.dev.devOnlyTest("Setting a value with only a get() generates a warning (#202)", function() {
 	QUnit.expect(7);
 
-	var message = "can-define: Set value for property derivedProp ignored, as its definition has a zero-argument getter and no setter";
+	var message = "can-define: Set value for property VM{}.derivedProp ignored, as its definition has a zero-argument getter and no setter";
 	var finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
 		QUnit.equal(actualMessage, message, "Warning is expected message");
 		QUnit.ok(success);
@@ -1203,7 +1203,7 @@ testHelpers.dev.devOnlyTest("Setting a value with only a get() generates a warni
 
 	QUnit.equal(finishErrorCheck(), 1);
 
-	message = "can-define: Set value for property derivedProp on VM ignored, as its definition has a zero-argument getter and no setter";
+	message = "can-define: Set value for property VM{}.derivedProp ignored, as its definition has a zero-argument getter and no setter";
 	finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
 		QUnit.equal(actualMessage, message, "Warning is expected message");
 		QUnit.ok(success);
@@ -1216,7 +1216,7 @@ testHelpers.dev.devOnlyTest("Setting a value with only a get() generates a warni
 testHelpers.dev.devOnlyTest("warn on using a Constructor for small-t type definintions", function() {
 	QUnit.expect(2);
 
-	var message = "can-define: the definition for currency uses a constructor for \"type\". Did you mean \"Type\"?";
+	var message = 'can-define: the definition for VM{}.currency uses a constructor for "type". Did you mean "Type"?';
 	var finishErrorCheck = testHelpers.dev.willWarn(message);
 
 	function Currency() {
@@ -1238,11 +1238,11 @@ testHelpers.dev.devOnlyTest("warn on using a Constructor for small-t type defini
 
 	QUnit.equal(finishErrorCheck(), 1);
 
-	message = "can-define: the definition for currency on VM2 uses a constructor for \"type\". Did you mean \"Type\"?";
+	message = 'can-define: the definition for VM2{}.currency uses a constructor for "type". Did you mean "Type"?';
 	finishErrorCheck = testHelpers.dev.willWarn(message);
 
 	function VM2() {}
-	VM2.shortName = "VM2";
+
 	define(VM2.prototype, {
 		currency: {
 			type: Currency, // should be `Type: Currency`
@@ -1252,5 +1252,27 @@ testHelpers.dev.devOnlyTest("warn on using a Constructor for small-t type defini
 		}
 	});
 
+	QUnit.equal(finishErrorCheck(), 1);
+});
+
+testHelpers.dev.devOnlyTest("warn with constructor for Value instead of Default (#340)", function() {
+	QUnit.expect(1);
+
+	var message = "can-define: Change the 'Value' definition for VM{}.currency to 'Default'.";
+	var finishErrorCheck = testHelpers.dev.willWarn(message);
+
+	function Currency() {
+		return this;
+	}
+	Currency.prototype = {
+		symbol: "USD"
+	};
+
+	function VM() {}
+	define(VM.prototype, {
+		currency: {
+			Value: Currency
+		}
+	});
 	QUnit.equal(finishErrorCheck(), 1);
 });

--- a/test/test-define-only.js
+++ b/test/test-define-only.js
@@ -1178,13 +1178,15 @@ QUnit.test('defined properties are configurable', function(){
 testHelpers.dev.devOnlyTest("Setting a value with only a get() generates a warning (#202)", function() {
 	QUnit.expect(7);
 
-	var message = "can-define: Set value for property VM{}.derivedProp ignored, as its definition has a zero-argument getter and no setter";
+	var VM = function() {};
+
+	var message = "can-define: Set value for property "+canReflect.getName(VM)+".derivedProp ignored, as its definition has a zero-argument getter and no setter";
 	var finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
 		QUnit.equal(actualMessage, message, "Warning is expected message");
 		QUnit.ok(success);
 	});
 
-	var VM = function() {};
+
 	define(VM.prototype, {
 		derivedProp: {
 			get: function() {
@@ -1203,7 +1205,7 @@ testHelpers.dev.devOnlyTest("Setting a value with only a get() generates a warni
 
 	QUnit.equal(finishErrorCheck(), 1);
 
-	message = "can-define: Set value for property VM{}.derivedProp ignored, as its definition has a zero-argument getter and no setter";
+	message = "can-define: Set value for property "+canReflect.getName(VM)+"{}.derivedProp ignored, as its definition has a zero-argument getter and no setter";
 	finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
 		QUnit.equal(actualMessage, message, "Warning is expected message");
 		QUnit.ok(success);


### PR DESCRIPTION
fixes #340 


uses `canReflect.getName()` to get the constructor name.

Had to pass down the `typePrototype` so functions providing warnings could get the name.