### PR TITLE
moved set deprecation warning

### DIFF
--- a/map/map.js
+++ b/map/map.js
@@ -172,22 +172,8 @@ var DefineMap = Construct.extend("DefineMap",{
 	 * @function can-define/map/map.prototype.set set
 	 * @parent can-define/map/map.prototype
 	 *
-	 * @deprecated {3.10.1} Passing an {Object} to `.set` has been deprecated in favor of [can-define/map/map.prototype.assign] or [can-define/map/map.prototype.update]. `map.set(propName, value)` is _not_ deprecated.
 	 *
 	 * @description Sets multiple properties on a map instance or a property that wasn't predefined.
-	 *
-	 * @signature `map.set(props [,removeProps])`
-	 *
-	 * Assigns each value in `props` to a property on this map instance named after the
-	 * corresponding key in `props`, effectively merging `props` into the Map. If `removeProps` is true, properties not in
-	 * `props` will be set to `undefined`.
-	 *
-	 *   @param {Object} props A collection of key-value pairs to set.
-	 *   If any properties already exist on the map, they will be overwritten.
-	 *
-	 *   @param {Boolean} [removeProps=false] Whether to set keys not present in `props` to `undefined`.
-	 *
-	 *   @return {can-define/map/map} The map instance for chaining.
 	 *
 	 * @signature `map.set(propName, value)`
 	 *
@@ -197,6 +183,30 @@ var DefineMap = Construct.extend("DefineMap",{
 	 *   @param {String} propName The property to set.
 	 *   @param {*} value The value to assign to `propName`.
 	 *   @return {can-define/map/map} This map instance, for chaining.
+	 *
+	 * @signature `map.set(props [,removeProps])`
+	 * 
+	 * Assigns each value in `props` to a property on this map instance named after the
+	 * corresponding key in `props`, effectively merging `props` into the Map. If `removeProps` is true, properties not in
+	 * `props` will be set to `undefined`.
+	 *
+	 * <section class="warnings">
+   * <div class="deprecated warning">
+   * <h3>Deprecated 3.10.1</h3>
+   * <div class="signature-wrapper">
+   * <p>Passing an {Object} to <code>.set</code> has been deprecated in favor of <a href="map.prototype.assign.html" title="Sets multiple properties on a map instance or a property that wasn't predefined.">assign</a> or <a href="map.prototype.update.html" title="Sets multiple properties on a map instance or a property that wasn't predefined.">update</a>. <code>map.set(propName, value)</code> is <em>not</em> deprecated.</p>
+   * </div>
+   * </div>
+	 * </section>
+	 * 
+	 *   @param {Object} props A collection of key-value pairs to set.
+	 *   If any properties already exist on the map, they will be overwritten.
+	 *
+	 *   @param {Boolean} [removeProps=false] Whether to set keys not present in `props` to `undefined`.
+	 *
+	 *   @return {can-define/map/map} The map instance for chaining.
+	 *
+	 
 	 */
 	set: function(prop, value){
 		if(typeof prop === "object") {


### PR DESCRIPTION
Fixes #322 set deprecation warning
This literally cut and pastes the deprecation warning HTML and switches the order of the signatures to start with the non-deprecated signature.  The deprecated signature should be removed in the next major update.