### PR TITLE
362 fixing documentaiton

### DIFF
--- a/docs/TypeConstructor.md
+++ b/docs/TypeConstructor.md
@@ -37,7 +37,7 @@ A [can-define.types.propDefinition] that defines an inline [can-define/map/map] 
 
 @signature `[Type|propDefinition]`
 
-Defines an inline [can-define/list/list] type that's an array of `Type` or inline `propDefinition` [can-define/map/map]
+Defines an inline [can-define/list/list] type that's an array of `Type` or inline [can-define.types.propDefinition] [can-define/map/map]
 instances.  For example:
 
 ```js

--- a/docs/TypeConstructor.md
+++ b/docs/TypeConstructor.md
@@ -60,6 +60,8 @@ instances.  For example:
 ## Use
 
 ```js
+import { DefineMap } from "can";
+
 const Address = DefineMap.extend( {
 	street: "string",
 	city: "string"
@@ -75,3 +77,4 @@ const direction = new Direction( {
 	to: new Address( { street: "123 Greenview", city: "Libertyville" } )
 } );
 ```
+@codepen

--- a/docs/TypeConstructor.md
+++ b/docs/TypeConstructor.md
@@ -16,7 +16,7 @@ A constructor function can be provided that is called to convert incoming values
 }
 ```    
 
-`Type` is called before [can-define.types.type] and before [can-define.types.set]. It checks if the incoming value
+The `Type` constructor is called before the [can-define.types.type] property and before [can-define.types.set]. It checks if the incoming value
 is an [instanceof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) `Type`. If it is, or if it is `null` or `undefined`, it passes the original value through.  If not, it passes the original value to `new Type(originalValue)` and returns the
 new instance to be set.
 

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -11,37 +11,38 @@ type.  `identity` configures the result of [can-reflect.getIdentity].
 The following specifies that the `id` property values uniquely identifies `Todo`
 instances:
 
-```js
-import {DefineMap, Reflect} from "can";
+  ```js
+  import { DefineMap, Reflect } from "can";
 
-const Todo = DefineMap.extend("Todo",{
-    id: {type: "number", identity: true},
-    name: "string",
-    complete: "boolean"
-});
+  const Todo = DefineMap.extend("Todo",{
+      id: {type: "number", identity: true},
+      name: "string",
+      complete: "boolean"
+  });
 
-var todo = new Todo({id: 6, name: "mow lawn"});
+  var todo = new Todo({id: 6, name: "mow lawn"});
 
-Reflect.getIdentity(todo) //-> 6
-```
+  console.log(Reflect.getIdentity(todo)); //-> 6
+  ```
+  @codepen
 
 `identity` can be `true` for multiple properties. If multiple identity properties
 are specified, a sorted JSON string is returned:
 
-```js
-import {DefineMap, Reflect} from "can";
+  ```js
+  import { DefineMap, Reflect } from "can";
 
-const Grade = DefineMap.extend("Grade",{
-    classId: {type: "number", identity: true},
-    studentId: {type: "number", identity: true},
-    grade: "string"
-});
+  const Grade = DefineMap.extend("Grade",{
+      classId: {type: "number", identity: true},
+      studentId: {type: "number", identity: true},
+      grade: "string"
+  });
 
-var grade = new Grade({classId: 5, studentId: 7, grade: "A+"});
+  var grade = new Grade({classId: 5, studentId: 7, grade: "A+"});
 
-Reflect.getIdentity(grade) //-> '{"classId":5,"studentId":7}'
-```
-
+  console.log(Reflect.getIdentity(grade)); //-> '{"classId":5,"studentId":7}'
+  ```
+  @codepen
 
 
 @body

--- a/docs/serialize.md
+++ b/docs/serialize.md
@@ -44,7 +44,7 @@ Specifies the serialized value of a property.
 
 [can-define/map/map.prototype.serialize] is useful for serializing an instance into
 a more JSON-friendly form.  This can be used for many reasons, including saving a
-[can-connect]ed instance on the server or serializing [can-route.map can-route.map]'s internal
+[can-connect]ed instance on the server or serializing [can-route.data can-route.data]'s internal
 map for display in the hash or pushstate URL.
 
 The serialize property allows an opportunity to define how

--- a/docs/type.md
+++ b/docs/type.md
@@ -127,7 +127,7 @@ When a user tries to set this property, the resulting value will remain an array
 Setting type as `compute` allows for resolving a computed property with the .attr()
 method.
 
-```
+```js
 MyMap = DefineMap.extend({
     value: {
         type: "compute"

--- a/docs/type.md
+++ b/docs/type.md
@@ -87,10 +87,12 @@ as either:
 
 ### Basic Example
 
-The following example converts the `count` property to a number and the `items` property to an array:
+The following example converts the `count` property to a number and the `items` property to an array.
 
 ```js
-DefineMap.extend( {
+import { DefineMap } from "can";
+
+const Map = DefineMap.extend( {
 	count: { type: "number" },
 	items: {
 		type: function( newValue ) {
@@ -102,13 +104,13 @@ DefineMap.extend( {
 		}
 	}
 } );
+
+const map = new Map();
+map.assign({ count: "4", items: "1,2,3" });
+
+console.log(map.count, map.items); //-> 4 ["1", "2", "3"]
 ```
-
-When a user tries to set those properties like:
-
-    map.set({count: "4", items: "1,2,3"});
-
-The number converter will be used to turn count into 4, and the items type converter function will be used to turn items into [1,2,3].
+@codepen
 
 ### Preventing Arrays and Objects from Automatic Conversion
 

--- a/docs/type.md
+++ b/docs/type.md
@@ -134,8 +134,8 @@ MyMap = DefineMap.extend({
     }
 });
 
-var myMap = new MyMap();
-var c = compute(5);
+const myMap = new MyMap();
+const c = compute(5);
 
 myMap.value = c;
 myMap.value //-> 5
@@ -144,7 +144,7 @@ c(6);
 myMap.value //-> 6
 
 //Be sure if setting to pass the new compute
-var c2 = compute("a");
+const c2 = compute("a");
 myMap.value = c2;
 myMap.value //-> "a"
 ```

--- a/docs/type.md
+++ b/docs/type.md
@@ -128,7 +128,9 @@ Setting type as `compute` allows for resolving a computed property with the .att
 method.
 
 ```js
-MyMap = DefineMap.extend({
+import { DefineMap } from "can";
+
+const MyMap = DefineMap.extend({
     value: {
         type: "compute"
     }
@@ -138,13 +140,14 @@ const myMap = new MyMap();
 const c = compute(5);
 
 myMap.value = c;
-myMap.value //-> 5
+console.log(myMap.value); //-> 5
 
 c(6);
-myMap.value //-> 6
+console.log(myMap.value); //-> 6
 
 //Be sure if setting to pass the new compute
 const c2 = compute("a");
 myMap.value = c2;
-myMap.value //-> "a"
+console.log(myMap.value); //-> "a"
 ```
+@codepen

--- a/docs/type.md
+++ b/docs/type.md
@@ -152,4 +152,5 @@ const c2 = compute("a");
 myMap.value = c2;
 console.log(myMap.value); //-> "a"
 ```
-@codepen
+<!-- `compute` is undefined -->
+<!-- @codepen -->

--- a/docs/types.set.md
+++ b/docs/types.set.md
@@ -167,6 +167,8 @@ A set function provides a useful hook for performing side effect logic as a cert
 In the example below, Paginator DefineMap includes a `page` property, which derives its value entirely from other properties (limit and offset).  If something tries to set the `page` directly, the set method will set the value of `offset`:
 
 ```js
+import { DefineMap } from "can";
+
 const Paginate = DefineMap.extend( {
 	limit: "number",
 	offset: "number",
@@ -181,8 +183,12 @@ const Paginate = DefineMap.extend( {
 } );
 
 const p = new Paginate( { limit: 10, offset: 20 } );
-```
+p.set({ page: 13 });
 
+console.log(p.offset); //-> 120
+console.log(p.page); //-> 13
+```
+@codepen
 
 
 ## Merging

--- a/docs/types.set.md
+++ b/docs/types.set.md
@@ -155,7 +155,7 @@ map.prop; //-> "food";
 
 A set function provides a useful hook for performing side effect logic as a certain property is being changed.
 
-For example, in the example below, Paginator DefineMap includes a `page` property, which derives its value entirely from other properties (limit and offset).  If something tries to set the `page` directly, the set method will set the value of `offset`:
+In the example below, Paginator DefineMap includes a `page` property, which derives its value entirely from other properties (limit and offset).  If something tries to set the `page` directly, the set method will set the value of `offset`:
 
 ```js
 const Paginate = DefineMap.extend( {

--- a/docs/types.set.md
+++ b/docs/types.set.md
@@ -57,7 +57,7 @@ arguments the setter declares:
 
 ## Use
 
-A property's `set` function can be used to customize the behavior of when an attribute value is set.  Let'ss see some common cases:
+A property's `set` function can be used to customize the behavior of when an attribute value is set.  Let's see some common cases:
 
 #### Side effects
 
@@ -76,7 +76,7 @@ The following makes setting a `page` property update the `offset`:
 
 The following makes changing `makeId` un-define the `modelId` property:
 
-```
+```js
 {
 	makeId: {
 	    set: function(newValue){

--- a/docs/types.set.md
+++ b/docs/types.set.md
@@ -196,6 +196,8 @@ console.log(p.page); //-> 13
 By default, if a value returned from a setter is an object the effect will be to replace the property with the new object completely.
 
 ```js
+import { DefineMap } from "can";
+
 const Contact = DefineMap.extend( {
 	info: {
 		set: function( newVal ) {
@@ -208,17 +210,20 @@ const alice = new Contact( {
 	info: { name: "Alice Liddell", email: "alice@liddell.com" }
 } );
 
-const info  = alice.info;
+const info = alice.info;
 
 alice.info = { name: "Allison Wonderland", phone: "888-888-8888" };
 
-info === alice.info; // -> false
+console.log(info === alice.info); // -> false
 ```
+@codepen
 
 In contrast, you can merge properties with:
 
 ```js
-Contact = DefineMap.extend( {
+import { DefineMap } from "can";
+
+const Contact = DefineMap.extend( {
 	info: {
 		set: function( newVal ) {
 			if ( this.info ) {
@@ -234,12 +239,13 @@ const alice = new Contact( {
 	info: { name: "Alice Liddell", email: "alice@liddell.com" }
 } );
 
-const info  = alice.info;
+const info = alice.info;
 
 alice.info = { name: "Allison Wonderland", phone: "888-888-8888" };
 
-info === alice.info; // -> true
+console.log(info === alice.info); // -> true
 ```
+@codepen
 
 ## Batched Changes
 

--- a/docs/types.set.md
+++ b/docs/types.set.md
@@ -113,43 +113,52 @@ When a setter returns `undefined`, its behavior changes depending on the number 
 With 0 arguments, the original set value is set on the attribute.
 
 ```js
-MyMap = DefineMap.extend( {
+import { DefineMap } from "can";
+
+const MyMap = DefineMap.extend( {
 	prop: { set: function() {} }
 } );
 
 const map = new MyMap( { prop: "foo" } );
 
-map.prop; //-> "foo"
+console.log(map.prop); //-> "foo"
 ```
+@codepen
 
 With 1 argument, an `undefined` return value will set the property to `undefined`.  
 
 ```js
-MyMap = DefineMap.extend( {
+import { DefineMap } from "can";
+
+const MyMap = DefineMap.extend( {
 	prop: { set: function( newVal ) {} }
 } );
 
 const map = new MyMap( { prop: "foo" } );
 
-map.prop; //-> undefined
+console.log(map.prop); //-> undefined
 ```
+@codepen
 
 With 2 arguments, `undefined` leaves the property in place.  It is expected
 that `resolve` will be called:
 
 ```js
-MyMap = DefineMap.extend( {
+import { DefineMap } from "can";
+
+const MyMap = DefineMap.extend( {
 	prop: {
 		set: function( newVal, resolve ) {
-			setVal( newVal + "d" );
+			resolve( newVal + "d" );
 		}
 	}
 } );
 
 const map = new MyMap( { prop: "foo" } );
 
-map.prop; //-> "food";
+console.log(map.prop); //-> "food";
 ```
+@codepen
 
 ## Side effects
 

--- a/docs/value.md
+++ b/docs/value.md
@@ -139,7 +139,7 @@ remove all bindings.
 The following `time` property increments every second.  Notice how a function
 is returned to clear the interval when the property is returned:
 
-```js
+  ```js
 const Timer = DefineMap.extend( "Timer", {
 	time: {
 		value( prop ) {
@@ -160,8 +160,8 @@ const timer = new Timer();
 timer.on( "time", function( ev, newVal, oldVal ) {
 	console.log( newVal ); //-> logs a new date every second
 } );
-```
-
+  ```
+  @codepen
 
 @body
 

--- a/docs/value.md
+++ b/docs/value.md
@@ -41,7 +41,7 @@ For example, the following counts the number of times the `name` property change
   p.name = "Justin"; // logs name changed 1 times
   p.name = "Ramiya"; // logs name changed 2 times
   ```
-  @codepen
+  <!-- @codepen -->
 
 If the property defined by `value` is unbound, the `value` function will be called each time. Use `prop.resolve` synchronously
 to provide a value.
@@ -161,7 +161,7 @@ timer.on( "time", function( ev, newVal, oldVal ) {
 	console.log( newVal ); //-> logs a new date every second
 } );
   ```
-  @codepen
+  <!-- @codepen -->
 
 @body
 
@@ -192,7 +192,9 @@ passage of time.
 The following `fullNameChangeCount` increments every time `fullName` changes:
 
 ```js
-DefineMap.extend( "Person", {
+import { DefineMap } from "can";
+
+const Person = DefineMap.extend( "Person", {
 	first: "string",
 	last: "string",
 	fullName: {
@@ -204,10 +206,16 @@ DefineMap.extend( "Person", {
 		value( prop ) {
 			let count = 0;
 			prop.resolve( 0 );
-			prop.listenTo( "fullName", ()=> {
+			prop.listenTo( "fullName", () => {
 				prop.resolve( ++count );
 			} );
 		}
 	}
 } );
+
+const p = new Person({ first: "John", last: "Smith" });
+p.first = "Justin";
+p.last = "Meyer";
+console.log(p.fullNameChangeCount); //-> 2
 ```
+<!-- @codepen -->

--- a/docs/value.md
+++ b/docs/value.md
@@ -9,15 +9,16 @@ The `value` behavior is used to compose a property value from events dispatched
 by other properties on the map. It's similar to [can-define.types.get], but can
 be used to build property behaviors that [can-define.types.get] can not provide.
 
-`value` enables techniques very similar to using
-event streams and functional reactive programming. Use `prop.listenTo` to listen to events
-dispatched on the map or other observables,
-`prop.stopListening` to stop listening to those events if needed, and `prop.resolve`
-to set a new value on the observable. For example, the following
-counts the number of times the `name` property changed:
+`value` enables techniques very similar to using event streams and functional
+reactive programming. Use `prop.listenTo` to listen to events dispatched on
+the map or other observables, `prop.stopListening` to stop listening to those
+events if needed, and `prop.resolve` to set a new value on the observable.
+For example, the following counts the number of times the `name` property changed:
 
 ```js
-Person = DefineMap.extend( "Person", {
+import { DefineMap } from 'can';
+
+const Person = DefineMap.extend( "Person", {
 	name: "string",
 	nameChangeCount: {
 		value( prop ) {
@@ -37,7 +38,7 @@ p.on( "nameChangedCount", ( ev, newVal )=> {
 	console.log( "name changed", newVal, "times" );
 } );
 
-p.name = "Justin"; // logs name changed 1 times
+p.name = "Justin"); // logs name changed 1 times
 p.name = "Ramiya"; // logs name changed 2 times
 ```
 

--- a/docs/value.md
+++ b/docs/value.md
@@ -78,7 +78,7 @@ behavior:
   prop.listenTo( todos, "length", handler, "mutate" );
 
   // Binds to an `onValue` emitter:
-  prop.listenTo( observable, handler ); //
+  prop.listenTo( observable, handler );
   ```
 
 - __prop.stopListening(bindTarget, event, handler, queue)__ `{function(Any,String,Fuction,String)}`  A function that removes bindings

--- a/docs/value.md
+++ b/docs/value.md
@@ -171,7 +171,7 @@ The `value` behavior should be used where the [can-define.types.get] behavior ca
 not derive a property value from instantaneous values.  This often happens in situations
 where the fact that something changes needs to saved in the state of the application.
 
-Lets first see an example where [can-define.types.get] should be used, the
+Let's first see an example where [can-define.types.get] should be used, the
 ubiquitous `fullName` property.  The following creates a `fullName` property
 that derives its value from the instantaneous `first` and `last` values:
 

--- a/docs/value.md
+++ b/docs/value.md
@@ -15,32 +15,33 @@ the map or other observables, `prop.stopListening` to stop listening to those
 events if needed, and `prop.resolve` to set a new value on the observable.
 For example, the following counts the number of times the `name` property changed:
 
-```js
-import { DefineMap } from 'can';
+  ```js
+  import { DefineMap } from "can";
 
-const Person = DefineMap.extend( "Person", {
-	name: "string",
-	nameChangeCount: {
-		value( prop ) {
-			let count = 0;
+  const Person = DefineMap.extend( "Person", {
+    name: "string",
+    nameChangeCount: {
+      value( prop ) {
+        let count = 0;
 
-			prop.listenTo( "name", () => {
-				prop.resolve( ++count );
-			} );
+        prop.listenTo( "name", () => {
+          prop.resolve( ++count );
+        } );
 
-			prop.resolve( count );
-		}
-	}
-} );
+        prop.resolve( count );
+      }
+    }
+  } );
 
-const p = new Person();
-p.on( "nameChangedCount", ( ev, newVal )=> {
-	console.log( "name changed", newVal, "times" );
-} );
+  const p = new Person();
+  p.on( "nameChangedCount", ( ev, newVal )=> {
+    console.log( "name changed", newVal, "times" );
+  } );
 
-p.name = "Justin"); // logs name changed 1 times
-p.name = "Ramiya"; // logs name changed 2 times
-```
+  p.name = "Justin"; // logs name changed 1 times
+  p.name = "Ramiya"; // logs name changed 2 times
+  ```
+  @codepen
 
 If the property defined by `value` is unbound, the `value` function will be called each time. Use `prop.resolve` synchronously
 to provide a value.

--- a/docs/value.md
+++ b/docs/value.md
@@ -171,8 +171,8 @@ The `value` behavior should be used where the [can-define.types.get] behavior ca
 not derive a property value from instantaneous values.  This often happens in situations
 where the fact that something changes needs to saved in the state of the application.
 
-Let's first see an example where [can-define.types.get] should be used, the
-ubiquitous `fullName` property.  The following creates a `fullName` property
+Our next example shows how [can-define.types.get] should be used with the
+`fullName` property.  The following creates a `fullName` property
 that derives its value from the instantaneous `first` and `last` values:
 
 ```js

--- a/docs/value.md
+++ b/docs/value.md
@@ -34,7 +34,7 @@ For example, the following counts the number of times the `name` property change
   } );
 
   const p = new Person();
-  p.on( "nameChangedCount", ( ev, newVal )=> {
+  p.on( "nameChangedCount", ( ev, newVal ) => {
     console.log( "name changed", newVal, "times" );
   } );
 

--- a/docs/value.md
+++ b/docs/value.md
@@ -176,14 +176,20 @@ Our next example shows how [can-define.types.get] should be used with the
 that derives its value from the instantaneous `first` and `last` values:
 
 ```js
-DefineMap.extend( "Person", {
+import { DefineMap } from "can";
+
+const Person = DefineMap.extend( "Person", {
 	first: "string",
 	last: "string",
 	get fullName() {
 		return this.first + " " + this.last;
 	}
 } );
+
+const p = new Person({ first: "John", last: "Smith" });
+console.log(p.fullName); //-> "John Smith"
 ```
+@codepen
 
 [can-define.types.get] is great for these types of values. But [can-define.types.get]
 is unable to derive property values based on the change of values or the


### PR DESCRIPTION
This is a documentation update fixing many of the issues from #362 
## [can-define.types.identity.html](https://canjs.com/doc/can-define.types.identity.html)
- [x] [Boolean](https://canjs.com/doc/can-define.types.identity.html#Boolean) needs codepen-able examples that log the result.

## [can-define.types.serialize.html](https://canjs.com/doc/can-define.types.serialize.html)
- [x] [Use](https://canjs.com/doc/can-define.types.serialize.html#Use)'s first paragraph was probably meant to be a link. `can-route.map` -> `can-route.data`

## [can-define.types.set.html](https://canjs.com/doc/can-define.types.set.html)
- [x] [Use](https://canjs.com/doc/can-define.types.set.html#Use) _Lets see some common cases_ in first paragraph should be _Let's_.
- [x] [Use](https://canjs.com/doc/can-define.types.set.html#Use)'s second example doesn't have syntax highlighting.
- [x] [Behavior subhead](https://canjs.com/doc/can-define.types.set.html#Behaviordependsonthenumberofarguments_) should have codepen-able examples and properly log.
- [x] [Behavior subhead](https://canjs.com/doc/can-define.types.set.html#Behaviordependsonthenumberofarguments_)'s third example mention that `resolve` will be called, but never calls `resolve`.
- [x] [Side effects](https://canjs.com/doc/can-define.types.set.html#Sideeffects)' second paragraph _For example, in the example below_ is needlessly reiterative.
- [x] [Side effects](https://canjs.com/doc/can-define.types.set.html#Sideeffects) example should be codepen-able and log properly.

## [can-define.types.type.html](https://canjs.com/doc/can-define.types.type.html)
- [x] basic example runs as expected

## [can-define.types.typeConstructor.html](https://canjs.com/doc/can-define.types.typeConstructor.html)

- [x] I think being declarative on the first paragraph of [Type](https://canjs.com/doc/can-define.types.typeConstructor.html#Type) would be beneficial.
> Type is called before type and before set.
change to:
> The Type constructor is called before the type property...
- [x] For the sake of consistency propDefinition should either be linked in both [{propDefinition}](https://canjs.com/doc/can-define.types.typeConstructor.html#_propDefinition_) and [[Type|propDefinition]](https://canjs.com/doc/can-define.types.typeConstructor.html#_Type_propDefinition_), or neither.
- [x] [Use](https://canjs.com/doc/can-define.types.typeConstructor.html#Use) code example should be codepen-able. *Unsure what to log here*

## [can-define.types.value.html](https://canjs.com/doc/can-define.types.value.html)
- [x] Most examples on this page are ready for codepen, but don't function as expected.
