### PR TITLE
Make serialized lists observable

### DIFF
--- a/list/list-test.js
+++ b/list/list-test.js
@@ -1470,3 +1470,19 @@ QUnit.test("canReflect.getSchema", function(){
 
 	QUnit.equal(schema.values, MyType);
 });
+
+QUnit.test("Bound serialized lists update when they change length", function(){
+	QUnit.expect(1);
+	var list = new DefineList(["eggs"]);
+	var obs = new Observation(function(){
+		return list.serialize();
+	});
+
+	function onChange(val) {
+		QUnit.deepEqual(val, ["eggs", "toast"]);
+	}
+
+	canReflect.onValue(obs, onChange);
+	list.push("toast");
+	canReflect.offValue(obs, onChange);
+});

--- a/list/list.js
+++ b/list/list.js
@@ -1682,15 +1682,15 @@ canReflect.assignSymbols(DefineList.prototype, defineListProto);
 
 canReflect.setKeyValue(DefineList.prototype, canSymbol.iterator, function() {
 	var index = -1;
-	if(typeof this._length !== "number") {
-		this._length = 0;
+	if(typeof this.length !== "number") {
+		this.length = 0;
 	}
 	return {
 		next: function() {
 			index++;
 			return {
 				value: this[index],
-				done: index >= this._length
+				done: index >= this.length
 			};
 		}.bind(this)
 	};


### PR DESCRIPTION
This fixes an issue where lists, when serialized, were not observable.
Meaning adding or removing items from the list did not result in a
`length` event (changing the observation listening).

Fixes #372
