### PR TITLE
Updating can-define/map documentation

### DIFF
--- a/docs/deleteKey.md
+++ b/docs/deleteKey.md
@@ -5,17 +5,45 @@
 
 @signature `map.deleteKey(key)`
 
-Deletes a key that was added to an instance, but not pre-defined by the type.
+  Deletes a key that was added to an instance, but not pre-defined by the type.
+
+  ```js
+  import {DefineMap, Reflect} from "can";
+
+  const map = new DefineMap( {propA: "valueA"} );
+  console.log( map.propA ); //-> "valueA"
+
+  map.deleteKey("propA");
+  console.log( map.propA ); //-> undefined
+  ```
+  @codepen
+
+  @param {String} key A string of the key being deleted.
+
+  @return {can-define/map/map} The map instance for chaining.
+
+@body
+
+## Use
+
+If `deleteKey` is called on a pre-defined type it sets the value to `undefined`. This is to keep the setters and getters on all instances of that Type.
 
 ```js
-import {DefineMap} from "can";
+import {DefineMap, Reflect} from "can";
 
-var Type = DefineMap.extend({seal: false},{
-  propA: "string"
-});
+const Type = DefineMap.extend(
+  {seal: false},
+  {
+    propA: "string"
+  }
+);
 
-var map = new Type({propA: "valueA"});
+const map = new Type( {propA: "valueA"} );
 map.set("propB","valueB");
-map.deleteKey("propB"); // this works.
-map.deleteKey("propA"); // this does not work.
+map.deleteKey("propB"); // This works.
+map.deleteKey("propA"); // This doesn't delete the key, but does set the key to undefined.
+
+console.log( Reflect.getOwnKeys(map) ); //-> ["propA"]
+console.log( map.propA ); //-> undefined
 ```
+@codepen

--- a/map/docs/define-map.md
+++ b/map/docs/define-map.md
@@ -12,18 +12,21 @@
 
 @signature `new DefineMap([props])`
 
-The `can-define/map/map` module exports the `DefineMap` constructor function.  
+  The `can-define/map/map` module exports the `DefineMap` constructor function.
 
-Calling `new DefineMap(props)` creates a new instance of DefineMap or an [can-define/map/map.extend extended] DefineMap. Then, assigns every property on `props` to the new instance.  If props are passed that are not defined already, those property definitions are created.  If the instance should be sealed, it is sealed.
+  Calling `new DefineMap(props)` creates a new instance of DefineMap or an [can-define/map/map.extend extended] DefineMap. Then, assigns every property on `props` to the new instance.  If props are passed that are not defined already, those property definitions are created.  If the instance should be sealed, it is sealed.
 
-```js
-import DefineMap from "can-define/map/map";
+  ```js
+  import {DefineMap} from "can";
 
-const person = new DefineMap( {
-	first: "Justin",
-	last: "Meyer"
-} );
-```
+  const person = new DefineMap( {
+		first: "Justin",
+		last: "Meyer"
+  } );
+
+  console.log( person.serialize() ); //-> {first: "Justin", last: "Meyer"}
+  ```
+  @codepen
 
   Custom `DefineMap` types, with special properties and behaviors, can be defined with [can-define/map/map.extend].
 
@@ -43,12 +46,20 @@ Instances of `DefineMap` have all methods and properties from
 Example:
 
 ```js
-const MyType = DefineMap.extend( { prop: "string" } );
+import {DefineMap} from "can";
 
-const myInstance = new MyType( { prop: "VALUE" } );
+const MyType = DefineMap.extend( {prop: "string"} );
 
-myInstance.on( "prop", function( event, newVal, oldVal ) { /* ... */ } );
+const myInstance = new MyType( {prop: "VALUE"} );
+
+myInstance.on( "prop", ( event, newVal, oldVal ) => { 
+	console.log( newVal ); //-> "VALUE"
+	console.log( oldVal ); //-> "NEW VALUE"
+} );
+
+myInstance.set("prop", "NEW VALUE");
 ```
+@codepen
 
 
 ## Mixed-in type methods and properties
@@ -62,12 +73,16 @@ Extended `DefineMap` constructor functions have all methods and properties from
 Example:
 
 ```js
-const MyType = DefineMap.extend( { /* ... */ } );
+import {DefineMap, Reflect} from "can";
+const MyType = DefineMap.extend( {
+  prop: "string",
+} );
 
-canReflect.onInstancePatches( MyType, function( instance, patches ) {
-
+canReflect.onInstancePatches( MyType, ( instance, patches ) => {
+  console.log(instance, patches);
 } );
 ```
+<!-- @codepen -->
 
 ## Use
 
@@ -77,7 +92,7 @@ behavior.
 For example, a `Todo` type, with a `name` property, `completed` property, and a `toggle` method, might be defined like:
 
 ```js
-import DefineMap from "can-define/map/map";
+import {DefineMap} from "can";
 
 const Todo = DefineMap.extend( {
 	name: "string",
@@ -86,7 +101,12 @@ const Todo = DefineMap.extend( {
 		this.completed = !this.completed;
 	}
 } );
+
+const myTodo = new Todo({name: "my first todo!"});
+myTodo.toggle();
+console.log( myTodo.serialize() ); //-> {name: "my first todo!", completed: true}
 ```
+@codepen
 
 The _Object_ passed to `.extend` defines the properties and methods that will be
 on _instances_ of a `Todo`.  There are a lot of ways to define properties.  The
@@ -102,21 +122,36 @@ This also defines a `toggle` method that will be available on _instances_ of `To
 calling `new Todo()` as follows:
 
 ```js
+import {DefineMap} from "can";
+
+const Todo = DefineMap.extend( {
+	name: "string",
+	completed: { type: "boolean", default: false },
+	toggle: function() {
+		this.completed = !this.completed;
+	}
+} );
+
 const myTodo = new Todo();
 myTodo.name = "Do the dishes";
-myTodo.completed; //-> false
+console.log( myTodo.completed ); //-> false
 
 myTodo.toggle();
-myTodo.completed; //-> true
-```  
+console.log( myTodo.completed ); //-> true
+```
+@codepen
+@highlight 11
 
 You can also pass initial properties and their values when initializing a `DefineMap`:
 
 ```js
+import {Todo} from "//unpkg.com/can-demo-models@5";
+
 const anotherTodo = new Todo( { name: "Mow lawn", completed: true } );
-myTodo.name = "Mow lawn";
-myTodo.completed; //-> true
-```  
+
+console.log( anotherTodo.name ); //-> "Mow lawn"
+```
+@codepen
 
 ## Declarative properties
 
@@ -125,6 +160,8 @@ that functionally derive their value from other property values.  This is done b
 defining [can-define.types.get getter] properties like `fullName` as follows:
 
 ```js
+import {DefineMap} from "can":
+
 const Person = DefineMap.extend( {
 	first: "string",
 	last: "string",
@@ -134,11 +171,22 @@ const Person = DefineMap.extend( {
 		}
 	}
 } );
+
+const person = new Person({
+	first: "Justin",
+	last: "Meyer"
+});
+
+console.log(person.fullName); //-> "Justin Meyer"
 ```
+@codepen
+@highlight 7-9
 
 `fullName` can also be defined with the ES5 shorthand getter syntax:
 
 ```js
+import {DefineMap} from "can";
+
 const Person = DefineMap.extend( {
 	first: "string",
 	last: "string",
@@ -146,31 +194,52 @@ const Person = DefineMap.extend( {
 		return this.first + " " + this.last;
 	}
 } );
+
+const person = new Person({
+	first: "Justin",
+	last: "Meyer"
+});
+
+console.log(person.fullName); //-> "Justin Meyer"
 ```
+@codepen
+@highlight 6-8
 
 Now, when a `person` is created, there is a `fullName` property available like:
 
 ```js
+import {Person} from "//unpkg.com/can-demo-models@5";
+
 const me = new Person( { first: "Harry", last: "Potter" } );
-me.fullName; //-> "Harry Potter"
+console.log( me.fullName ); //-> "Harry Potter"
 ```
+@codepen
+@highlight 4
 
 This property can be bound to like any other property:
 
 ```js
-me.on( "fullName", function( ev, newValue, oldValue ) {
-	newValue; //-> Harry Henderson
-	oldValue; //-> Harry Potter
+import {Person} from "//unpkg.com/can-demo-models@5";
+
+const me = new Person({first: "Harry", last: "Potter"});
+
+me.on( "fullName", ( ev, newValue, oldValue ) => {
+	console.log( newValue ); //-> Harry Henderson
+	console.log( oldValue ); //-> Harry Potter
 } );
 
 me.last = "Henderson";
 ```
+@codepen
+@highlight 4-8
 
 `getter` properties use [can-compute] internally.  This means that when bound,
 the value of the `getter` is cached and only updates when one of its source
 observables change.  For example:
 
 ```js
+import {DefineMap} from "can";
+
 const Person = DefineMap.extend( {
 	first: "string",
 	last: "string",
@@ -183,15 +252,15 @@ const Person = DefineMap.extend( {
 const hero = new Person( { first: "Wonder", last: "Woman" } );
 
 // console.logs "calculating fullName"
-hero.fullName; //-> Wonder Woman
+console.log( hero.fullName ); //-> Wonder Woman
 
 // console.logs "calculating fullName"
-hero.fullName; //-> Wonder Woman
+console.log( hero.fullName ); //-> Wonder Woman
 
 // console.logs "calculating fullName"
-hero.on( "fullName", function() {} );
+hero.on( "fullName", () => {} );
 
-hero.fullName; //-> "Wonder Woman"
+console.log( hero.fullName ); //-> "Wonder Woman"
 
 // console.logs "calculating fullName"
 hero.first = "Bionic";
@@ -199,23 +268,43 @@ hero.first = "Bionic";
 // console.logs "calculating fullName"
 hero.last = "Man";
 
-hero.fullName; //-> "Bionic Man"
+console.log( hero.fullName ); //-> "Bionic Man"
 ```
+@codepen
 
 If you want to prevent repeat updates, use [can-queues.batch.start]:
 
 ```js
-hero.fullName; //-> "Bionic Man"
+import {queues} from "//unpkg.com/can@5/core.mjs"
+import {Person} from "//unpkg.com/can-demo-models@5";
 
-import canBatch from "can-event/batch/batch";
+// Extending person to log repeat updates.
+const CustomPerson = Person.extend( {
+  get fullName() {
+    console.log( "calculating fullName" );
+    return this.first + " " + this.last;
+  }
+} );
 
-canBatch.start();
-hero.first = "Silk";
-hero.last = "Spectre";
+const hero = new CustomPerson();
+
+hero.on( "fullName", () => {} );
 
 // console.logs "calculating fullName"
-canBatch.stop();
+hero.first = "Bionic";
+// console.logs "calculating fullName"
+hero.last = "Man";
+// console.logs "calculating fullName"
+console.log( hero.fullName ); //-> "Bionic Man"
+
+queues.batch.start();
+hero.first = "Silk";
+hero.last = "Spectre";
+// console.logs "calculating fullName"
+queues.batch.stop();
 ```
+@codepen
+@highlight 23, 27
 
 ### Asynchronous getters
 
@@ -225,7 +314,7 @@ view-models.  For example, a `view-model` might take a `todoId` value, and want
 to make a `todo` property available:
 
 ```js
-import ajax from "can-ajax";
+import {DefineMap, ajax} from "can";
 
 const TodoViewModel = DefineMap.extend( {
 	todoId: "number",
@@ -236,22 +325,26 @@ const TodoViewModel = DefineMap.extend( {
 	}
 } );
 ```
+<!-- @codepen -->
 
 Asynchronous getters only are passed a `resolve` argument when bound.  Typically in an application,
 your template will automatically bind on the `todo` property.  But to use it in a test might
 look like:
 
 ```js
-import fixture from "can-fixture";
-fixture( "GET /todos/5", function() {
+import {fixture} from "can";
+
+fixture( "GET /todos/5", () => {
 	return { id: 5, name: "take out trash" };
 } );
 
 const todoVM = new TodoViewModel( { id: 5 } );
+
 todoVM.on( "todo", function( ev, newVal ) {
 	assert.equal( newVal.name, "take out trash" );
 } );
 ```
+<!-- @codepen -->
 
 ### Getter limitations
 
@@ -266,7 +359,9 @@ we want to clear the choice of __city__ whenever the __state__ changes.
 This can be implemented with [can-define.types.set] like:
 
 ```js
-Locator = DefineMap.extend( {
+import {DefineMap} from "can";
+
+const Locator = DefineMap.extend( {
 	state: {
 		type: "string",
 		set: function() {
@@ -282,8 +377,9 @@ const locator = new Locator( {
 } );
 
 locator.state = "CA";
-locator.city; //-> null;
+console.log( locator.city ); //-> null;
 ```
+@codepen
 
 The problem with this code is that it relies on side effects to manage the behavior of
 `city`.  If someone wants to understand how `city` behaves, they might have search the entire
@@ -293,10 +389,12 @@ The [can-define.types.value] behavior and [can-define-stream-kefir] plugin allow
 behavior of a property to a single place.  For example, the following implements `Locator` with [can-define.types.value]:
 
 ```js
+import {DefineMap} from "can";
+
 const Locator = DefineMap.extend( "Locator", {
 	state: "string",
 	city: {
-		value: function( prop ) {
+		value: ( prop ) => {
 
 			// When city is set, update `city` with the set value.
 			prop.listenTo( prop.lastSet, prop.resolve );
@@ -311,7 +409,16 @@ const Locator = DefineMap.extend( "Locator", {
 		}
 	}
 } );
+
+const locator = new Locator( {
+	state: "IL",
+	city: "Chicago",
+} );
+
+locator.state = "CA";
+console.log( locator.city ); //-> null
 ```
+@codepen
 
 While [functional reactive programming](https://en.wikipedia.org/wiki/Functional_reactive_programming) (FRP) can take time to
 master at first, once you do, your code will be much easier to understand and
@@ -320,17 +427,27 @@ in other properties and `resolve` the property to a new value.  If you are looki
 checkout [can-define-stream-kefir], which supports a full streaming library with many event-stream transformations:
 
 ```js
+import {DefineMap} from "can";
+
 const Locator = DefineMap.extend( {
 	state: "string",
 	city: {
 		stream: function( setStream ) {
-			return this.stream( ".state" ).map( function() {
-				return null;
-			} ).merge( setStream );
+			return this.stream( ".state" )
+				.map( () => null )
+				.merge( setStream );
 		}
 	}
 } );
+
+const location = new Locator({
+	state: "Illinois",
+	city: "Chicago"
+});
+
+console.log( location.serialize() );
 ```
+@codepen
 
 Notice, in the `can-define-stream` example, `city` must be bound for it to work.  
 
@@ -342,8 +459,7 @@ will throw an error in files that are in [strict mode](https://developer.mozilla
 
 ```js
 "use strict";
-
-import DefineMap from "can-define/map/map";
+import DefineMap from "can";
 
 const MyType = DefineMap.extend( {
 	myProp: "string"
@@ -352,8 +468,8 @@ const MyType = DefineMap.extend( {
 const myType = new MyType();
 
 myType.myProp = "value"; // no error thrown
-
 myType.otherProp = "value"; // throws Error!
 ```
+@codepen
 
 Read the [can-define/map/map.seal] documentation for more information on this behavior.

--- a/map/docs/events.keys.md
+++ b/map/docs/events.keys.md
@@ -5,14 +5,15 @@ Event fired when a property is added.
 
 @signature `handler(event)`
 
-Handlers registered on `can.keys` events will be called
-back as follows.
+  Handlers registered on `can.keys` events will be called
+  back as follows.
 
-```
-var person = new DefineMap({name: "Justin"});
-list.on("can.keys", function(event){ ... });
-person.set("age", 33);
-```
-
+  ```js
+  import {DefineMap} from "can";
+  var person = new DefineMap({name: "Justin"});
+  list.on("can.keys", (event) => { console.log(event); });
+  person.set("age", 33);
+  ```
+  @codepen
 
   @param {Event} event An event object.

--- a/map/docs/events.keys.md
+++ b/map/docs/events.keys.md
@@ -10,8 +10,12 @@ Event fired when a property is added.
 
   ```js
   import {DefineMap} from "can";
-  var person = new DefineMap({name: "Justin"});
-  list.on("can.keys", (event) => { console.log(event); });
+
+  const person = new DefineMap({name: "Justin"});
+
+  list.on("can.keys", (event) => {
+    console.log(event.target.serialize()); //-> {name: "Justin", age: 33}
+  });
   person.set("age", 33);
   ```
   @codepen

--- a/map/docs/events.propertyName.md
+++ b/map/docs/events.propertyName.md
@@ -5,18 +5,21 @@ Event fired when a property on the map changes values.
 
 @signature `handler(event, newValue, oldValue)`
 
-Handlers registered on `propertyName` events will be called
-back as follows.
+  Handlers registered on `propertyName` events will be called
+  back as follows.
 
-```
-var person = new DefineMap({name: "Justin"});
-list.on("name", function(event, newVal, oldVal){
-  newVal //-> "Brian"
-  oldVal //-> "Justin"
-});
-person.name = "Brian";
-```
+  ```js
+  import {DefineMap} from "can";
 
+  const person = new DefineMap({name: "Justin"});
+
+  person.on("name", (event, newVal, oldVal) => {
+    console.log( newVal ); //-> "Brian"
+    console.log( oldVal ); //-> "Justin"
+  });
+  person.name = "Brian";
+  ```
+  @codepen
 
   @param {Event} event An event object.
   @param {*} newVal The new value of the `propertyName` property.

--- a/map/docs/prototype.assign.md
+++ b/map/docs/prototype.assign.md
@@ -6,11 +6,11 @@
 @signature `map.assign(props)`
 
   ```js
-  var MyMap = DefineMap.extend({
+  const MyMap = DefineMap.extend({
     list: DefineList,
     name: 'string'
   });
-  var obj = new MyMap({
+  const obj = new MyMap({
     list: ['1', '2', '3'],
     foo: 'bar'
   });
@@ -18,9 +18,11 @@
     list: ['first']
   });
 
-  obj.list //-> ['first']
-  obj.foo //-> 'bar'
+  console.log(obj.list.serialize()); //-> ['first']
+  console.log(obj.foo); //-> 'bar'
   ```
+  @codepen
+
   Assigns each value in `props` to a property on this map instance named after the
   corresponding key in `props`, effectively replacing `props` into the Map.
   Properties not in `props` will not be changed.

--- a/map/docs/prototype.assign.md
+++ b/map/docs/prototype.assign.md
@@ -6,20 +6,24 @@
 @signature `map.assign(props)`
 
   ```js
+  import {DefineMap, DefineList} from "can";
+
   const MyMap = DefineMap.extend({
     list: DefineList,
-    name: 'string'
-  });
-  const obj = new MyMap({
-    list: ['1', '2', '3'],
-    foo: 'bar'
-  });
-  obj.assign({
-    list: ['first']
+    name: "string"
   });
 
-  console.log(obj.list.serialize()); //-> ['first']
-  console.log(obj.foo); //-> 'bar'
+  const obj = new MyMap({
+    list: ["1", "2", "3"],
+    foo: "bar"
+  });
+
+  obj.assign({
+    list: ["first"]
+  });
+
+  console.log(obj.list.serialize()); //-> ["first"]
+  console.log(obj.foo); //-> "bar"
   ```
   @codepen
 

--- a/map/docs/prototype.assignDeep.md
+++ b/map/docs/prototype.assignDeep.md
@@ -10,21 +10,26 @@
   Properties not in `props` will not be changed.
 
   ```js
-  var MyMap = DefineMap.extend({
+  import {DefineMap, DefineList} from "can";
+
+  const MyMap = DefineMap.extend({
     list: DefineList,
-    name: 'string'
-  });
-  var obj = new MyMap({
-    list: ['1', '2', '3'],
-    foo: 'bar'
-  });
-  obj.assignDeep({
-    list: ['first']
+    name: "string"
   });
 
-  obj.list //-> ['first']
-  obj.foo //-> 'bar'
+  const obj = new MyMap({
+    list: ["1", "2", "3"],
+    foo: "bar"
+  });
+
+  obj.assignDeep({
+    list: ["first"]
+  });
+
+  console.log(obj.list.serialize()); //-> ["first", "2", "3"]
+  console.log(obj.foo); //-> "bar"
   ```
+  @codepen
 
   @param {Object} props A collection of key-value pairs to set.
   If any properties already exist on the map, they will be overwritten.

--- a/map/docs/prototype.forEach.md
+++ b/map/docs/prototype.forEach.md
@@ -3,19 +3,26 @@
 
 @description Call a function on each property of a DefineMap.
 
-@signature `map.forEach( callback(value, propName ) )`
+@signature `map.forEach( callback( value, propName ) )`
 
-`forEach` iterates through the map instance, calling a function
-for each property value and key.
+  `forEach` iterates through the map instance, calling a function
+  for each property value and key.
 
-```js
-map.forEach( function( value, propName ) { /* ... */ } );
-```
+  ```js
+  import {DefineMap} from "can";
+
+  const names = [];
+  const map = new DefineMap({a: "Alice", b: "Bob", e: "Eve"});
+
+  map.forEach( (value, propName) => names.push(value) );
+
+  console.log( names ); //-> ["Alice", "Bob", "Eve"]
+  ```
+  @codepen
 
   @param {function(*,String)} callback(value,propName) The function to call for each property
   The value and key of each property will be passed as the first and second
-  arguments, respectively, to the callback. If the callback returns `false`,
-  the loop will stop.
+  arguments, respectively, to the callback.
 
   @return {can-define/map/map} The map instance for chaining.
 
@@ -23,23 +30,21 @@ map.forEach( function( value, propName ) { /* ... */ } );
 
 ## Use
 
-Example
+If the callback returns `false` the loop will stop.
 
+```js
+import {DefineMap} from "can";
+
+const names = [];
+const map = new DefineMap({a: "Alice", b: "Bob", e: "Eve"});
+
+map.forEach( (value, propName) => {
+  if (propName === "e") {
+    return false;
+  }
+  names.push(value);
+} );
+
+console.log( names ); //-> ["Alice", "Bob"]
 ```
-var names = [];
-new DefineMap({a: 'Alice', b: 'Bob', e: 'Eve'}).forEach(function(value, key) {
-    names.push(value);
-});
-
-names; // ['Alice', 'Bob', 'Eve']
-
-names = [];
-new DefineMap({a: 'Alice', b: 'Bob', e: 'Eve'}).forEach(function(value, key) {
-    names.push(value);
-    if(key === 'b') {
-        return false;
-    }
-});
-
-names; // ['Alice', 'Bob']
-```
+@codepen

--- a/map/docs/prototype.get.md
+++ b/map/docs/prototype.get.md
@@ -14,9 +14,12 @@
   Use [can-define/map/map.prototype.serialize] when a form proper for `JSON.stringify` is needed.
 
   ```js
-  var map = new DefineMap({foo: new DefineMap({bar: "zed"})});
-  map.get() //-> {foo: {bar: "zed"}};
+  import {DefineMap} from "can";
+
+  const map = new DefineMap({foo: new DefineMap({bar: "zed"})});
+  console.log( map.get() ); //-> {foo: {bar: "zed"}};
   ```
+  @codepen
 
   @return {Object} A plain JavaScript `Object` that contains all the properties and values of the map instance.
 
@@ -28,9 +31,12 @@
   will be later via [can-define/map/map.prototype.set].
 
   ```js
-  var map = new DefineMap();
-  map.get("name") //-> undefined;
+  import {DefineMap} from "can";
+
+  const map = new DefineMap();
+  console.log( map.get("name") ); //-> undefined;
   ```
+  @codepen
 
   @param {String} propName The property name of a property that may not have been defined yet.
   @return {*} The value of that property.

--- a/map/docs/prototype.serialize.md
+++ b/map/docs/prototype.serialize.md
@@ -13,17 +13,20 @@
   `undefined` serialized values are not added to the result.
 
   ```js
-  var MyMap = DefineMap.extend({
+  import {DefineMap} from "can";
+
+  const MyMap = DefineMap.extend({
     date: {
       type: "date",
-      serialize: function(date){
-        return date.getTime()
+      serialize: (date) => {
+        return date.getTime();
       }
     }
   });
 
-  var myMap = new MyMap({date: new Date(), count: 5});
-  myMap.serialize() //-> {date: 1469566698504, count: 5}
+  const myMap = new MyMap({date: new Date(), count: 5});
+  console.log( myMap.serialize() ); //-> {date: 1469566698504, count: 5}
   ```
+  @codepen
 
   @return {Object} A JavaScript Object that can be serialized with `JSON.stringify` or other methods.

--- a/map/docs/prototype.set.md
+++ b/map/docs/prototype.set.md
@@ -8,6 +8,16 @@
   Assigns _value_ to a property on this map instance called _propName_.  This will define
   the property if it hasn't already been predefined.
 
+  ```js
+  import {DefineMap} from "can";
+
+  const map = new DefineMap({});
+  map.set("propA", "value");
+
+  console.log( map.serialize() ); //-> {propA: "value"} 
+  ```
+  @codepen
+
   @param {String} propName The property to set.
   @param {*} value The value to assign to `propName`.
   @return {can-define/map/map} This map instance, for chaining.

--- a/map/docs/prototype.update.md
+++ b/map/docs/prototype.update.md
@@ -6,21 +6,27 @@
 @signature `map.update(props)`
 
   ```js
-  var MyMap = DefineMap.extend({
+  import {DefineMap, DefineList} from "can";
+
+  const MyMap = DefineMap.extend({
     list: DefineList,
-    name: 'string'
-  });
-  var obj = new MyMap({
-    list: ['1', '2', '3'],
-    foo: 'bar'
-  });
-  obj.update({
-    list: ['first']
+    name: "string"
   });
 
-  obj.list //-> ['first', '2', '3']
-  obj.foo //-> 'undefined'
+  const obj = new MyMap({
+    list: ["1", "2", "3"],
+    foo: "bar"
+  });
+
+  obj.update({
+    list: ["first"]
+  });
+
+  console.log(obj.list); //-> ["first"]
+  console.log(obj.foo); //-> 'undefined'
   ```
+  @codepen
+ 
   Assigns each value in `props` to a property on this map instance named after the
   corresponding key in `props`, effectively merging `props` into the Map.
   Properties not in `props` will be set to `undefined`.

--- a/map/docs/prototype.update.md
+++ b/map/docs/prototype.update.md
@@ -22,8 +22,8 @@
     list: ["first"]
   });
 
-  console.log(obj.list); //-> ["first"]
-  console.log(obj.foo); //-> 'undefined'
+  console.log( obj.list ); //-> ["first"]
+  console.log( obj.foo ); //-> 'undefined'
   ```
   @codepen
  

--- a/map/docs/prototype.updateDeep.md
+++ b/map/docs/prototype.updateDeep.md
@@ -14,28 +14,28 @@
 
   const MyMap = DefineMap.extend({
     list: DefineList,
-    name: 'string'
+    name: "string"
   });
 
   const obj = new MyMap({
-    list: ['1', '2', '3'],
-    name: 'bar',
+    list: ["1", "2", "3"],
+    name: "bar",
     foo: {
-      bar: 'zed',
-      boo: 'goo'
+      bar: "zed",
+      boo: "goo"
     }
   });
 
   obj.updateDeep({
-    list: ['first'],
+    list: ["first"],
     foo: {
-      bar: 'abc'
+      bar: "abc"
     }
   });
 
-  console.log( obj.list ); //-> ['first', '2', '3']
-  console.log( obj.foo ); //-> { bar: 'abc', boo: undefined }
-  console.log( obj.name ); //-> 'undefined'
+  console.log( obj.list ); //-> ["first"]
+  console.log( obj.foo ); //-> { bar: "abc", boo: undefined }
+  console.log( obj.name ); //-> "undefined"
   ```
   @codepen
 

--- a/map/docs/prototype.updateDeep.md
+++ b/map/docs/prototype.updateDeep.md
@@ -10,11 +10,14 @@
   Properties not in `props` will be set to `undefined`.
 
   ```js
-  var MyMap = DefineMap.extend({
+  import {DefineMap, DefineList} from "can";
+
+  const MyMap = DefineMap.extend({
     list: DefineList,
     name: 'string'
   });
-  var obj = new MyMap({
+
+  const obj = new MyMap({
     list: ['1', '2', '3'],
     name: 'bar',
     foo: {
@@ -22,6 +25,7 @@
       boo: 'goo'
     }
   });
+
   obj.updateDeep({
     list: ['first'],
     foo: {
@@ -29,10 +33,12 @@
     }
   });
 
-  obj.list //-> ['first', '2', '3']
-  obj.foo	//-> { bar: 'abc', boo: undefined }
-  obj.name //-> 'undefined'
+  console.log( obj.list ); //-> ['first', '2', '3']
+  console.log( obj.foo ); //-> { bar: 'abc', boo: undefined }
+  console.log( obj.name ); //-> 'undefined'
   ```
+  @codepen
+
   @param {Object} props A collection of key-value pairs to set.
   If any properties already exist on the map, they will be overwritten.
 

--- a/map/docs/prototype.wildcard.md
+++ b/map/docs/prototype.wildcard.md
@@ -5,35 +5,35 @@
 
 @option {can-define.types.propDefinition}
 
-By defining a wildcard property like `"*"` on the prototype, this will supply a
-default behavior for every property.  The default wildcard `"*"` definition
-makes every property run through the "observable" [can-define.types] converter.
-It looks like:
+  By defining a wildcard property like `"*"` on the prototype, this will supply a
+  default behavior for every property.  The default wildcard `"*"` definition
+  makes every property run through the "observable" [can-define.types] converter.
+  It looks like:
 
-```
-"*": {
-  type: "observable"
-}
-```
-
-Setting the wildcard is useful when every property on a
-map instance should behave in a particular way.  For example, for map types used
-with [can-route]:
-
-```
-var MyMap = DefineMap.extend({
+  ```js
   "*": {
-    type: "stringOrObservable"
+    type: "observable"
   }
-})
-```
+  ```
 
-Or if you want to turn off implicit conversion of Objects and Arrays to DefineMap and DefineLists:
+  Setting the wildcard is useful when every property on a
+  map instance should behave in a particular way.  For example, for map types used
+  with [can-route]:
 
-```
-var MyMap = DefineMap.extend({
-  "*": {
-    type: "*"
-  }
-})
-```
+  ```js
+  const MyMap = DefineMap.extend({
+    "*": {
+      type: "stringOrObservable"
+    }
+  });
+  ```
+
+  Or if you want to turn off implicit conversion of Objects and Arrays to DefineMap and DefineLists:
+
+  ```js
+  const MyMap = DefineMap.extend({
+    "*": {
+      type: "*"
+    }
+  });
+  ```

--- a/map/docs/static.extend.md
+++ b/map/docs/static.extend.md
@@ -5,30 +5,32 @@
 
 @signature `DefineMap.extend([name,] [static,] prototype)`
 
-Extends DefineMap, or constructor functions derived from DefineMap,
-to create a new constructor function.
+  Extends DefineMap, or constructor functions derived from DefineMap,
+  to create a new constructor function.
 
-```js
-import DefineMap from "can-define/map/map";
+  ```js
+  import {DefineMap} from "can";
 
-const Person = DefineMap.extend(
-	"Person",
-	{ seal: true },
-	{
-		first: "string",
-		last: { type: "string" },
-		fullName: {
-			get: function() {
-				return this.first + " " + this.last;
-			}
-		},
-		age: { default: 0 }
-	} );
+  const Person = DefineMap.extend(
+    "Person",
+    { seal: true },
+    {
+      first: "string",
+      last: { type: "string" },
+      fullName: {
+        get: function() {
+          return this.first + " " + this.last;
+        }
+      },
+      age: { default: 0 }
+    }
+  );
 
-const me = new Person( { first: "Justin", last: "Meyer" } );
-me.fullName; //-> "Justin Meyer"
-me.age;      //-> 0
-```
+  const me = new Person( { first: "Justin", last: "Meyer" } );
+  console.log( me.fullName ); //-> "Justin Meyer"
+  console.log( me.age ); //-> 0
+  ```
+  @codepen
 
   @param {String} [name] Provides an optional name for this type that will
   show up nicely in debuggers.
@@ -38,75 +40,91 @@ me.age;      //-> 0
 
   @param {Object<String,Function|can-define.types.propDefinition>} prototype A definition of the properties or methods on this type.
 
+@body
+
+## Use
+
   If the property definition is a __plain function__, it's considered a method.
 
   ```js
-const Person = DefineMap.extend( {
-	sayHi: function() {
-		console.log( "hi" );
-	}
-} );
+  import {DefineMap} from "can";
 
-const me = new Person();
-me.sayHi();
-```
+  const Person = DefineMap.extend( {
+    sayHi: function() {
+      console.log( "hi" );
+    }
+  } );
+
+  const me = new Person();
+  me.sayHi(); //-> "hi"
+  ```
+  @codepen
 
   If the property definition is a __string__, it's considered a `type` setting to be looked up in [can-define.types can-define.types].
 
   ```js
-const Person = DefineMap.extend( {
-	age: "number",
-	isCool: "boolean",
-	hobbies: "observable"
-} );
+  import {DefineMap, DefineList} from "can";
 
-const me = new Person( { age: "33", isCool: "false", hobbies: [ "js", "bball" ] } );
-me.age;    //-> 33
-me.isCool; //-> false
-me.hobbies instanceof DefineList; //-> true
-```
+  const Person = DefineMap.extend( {
+    age: "number",
+    isCool: "boolean",
+    hobbies: "observable"
+  } );
+
+  const me = new Person( { age: "33", isCool: "false", hobbies: [ "js", "bball" ] } );
+  console.log( me.age ); //-> 33
+  console.log( me.isCool ); //-> false
+  console.log( me.hobbies instanceof DefineList ); //-> true
+  ```
+  @codepen
 
 
   If the property definition is a Constructor function, it's considered a `Type` setting.
 
   ```js
-const Address = DefineMap.extend( {
-	zip: "number"
-} );
-const Person = DefineMap.extend( {
-	address: Address
-} );
+  import {DefineMap} from "can";
 
-const me = new Person( { address: { zip: "60048" } } );
-me.address.zip; //-> 60048
-```
+  const Address = DefineMap.extend( {
+    zip: "number"
+  } );
+  const Person = DefineMap.extend( {
+    address: Address
+  } );
+
+  const me = new Person( { address: { zip: "60048" } } );
+  console.log( me.address.zip ); //-> 60048
+  ```
+  @codepen
 
   If the property is an __object__, it's considered to be a [can-define.types.propDefinition].
 
   ```js
-const Person = DefineMap.extend( {
-	fullName: {
-		get: function() {
-			return this.first + " " + this.last;
-		},
-		set: function( newVal ) {
-			const parts = newVal.split( " " );
-			this.first = parts[ 0 ];
-			this.last = parts[ 1 ];
-		}
-	},
+  import {DefineMap} from "can";
 
-	// slick way of creating an 'inline' type.
-	address: {
-		Type: {
-			zip: "number"
-		}
-	}
-} );
+  const Person = DefineMap.extend( {
+    fullName: {
+      get: function() {
+        return this.first + " " + this.last;
+      },
+      set: function( newVal ) {
+        const parts = newVal.split( " " );
+        this.first = parts[ 0 ];
+        this.last = parts[ 1 ];
+      }
+    },
 
-const me = new Person( { fullName: "Rami Myer", address: { zip: "60048" } } );
-me.first;       //-> "Rami"
-me.address.zip; //-> 60048
-```
+    // slick way of creating an 'inline' type.
+    address: {
+      Type: {
+        zip: "number"
+      }
+    }
+  } );
 
-@return {can-define/map/map} A DefineMap constructor function.
+  const me = new Person( { fullName: "Rami Myer", address: { zip: "60048" } } );
+  console.log( me.first ); //-> "Rami"
+  console.log( me.address.zip ); //-> 60048
+  ```
+  @codepen
+
+  @return {can-define/map/map} A DefineMap constructor function.

--- a/map/docs/static.extend.md
+++ b/map/docs/static.extend.md
@@ -44,87 +44,87 @@
 
 ## Use
 
-  If the property definition is a __plain function__, it's considered a method.
+If the property definition is a __plain function__, it's considered a method.
 
-  ```js
-  import {DefineMap} from "can";
+```js
+import {DefineMap} from "can";
 
-  const Person = DefineMap.extend( {
-    sayHi: function() {
-      console.log( "hi" );
-    }
-  } );
+const Person = DefineMap.extend( {
+  sayHi: function() {
+    console.log( "hi" );
+  }
+} );
 
-  const me = new Person();
-  me.sayHi(); //-> "hi"
-  ```
-  @codepen
+const me = new Person();
+me.sayHi(); //-> "hi"
+```
+@codepen
 
-  If the property definition is a __string__, it's considered a `type` setting to be looked up in [can-define.types can-define.types].
+If the property definition is a __string__, it's considered a `type` setting to be looked up in [can-define.types can-define.types].
 
-  ```js
-  import {DefineMap, DefineList} from "can";
+```js
+import {DefineMap, DefineList} from "can";
 
-  const Person = DefineMap.extend( {
-    age: "number",
-    isCool: "boolean",
-    hobbies: "observable"
-  } );
+const Person = DefineMap.extend( {
+  age: "number",
+  isCool: "boolean",
+  hobbies: "observable"
+} );
 
-  const me = new Person( { age: "33", isCool: "false", hobbies: [ "js", "bball" ] } );
-  console.log( me.age ); //-> 33
-  console.log( me.isCool ); //-> false
-  console.log( me.hobbies instanceof DefineList ); //-> true
-  ```
-  @codepen
+const me = new Person( { age: "33", isCool: "false", hobbies: [ "js", "bball" ] } );
+console.log( me.age ); //-> 33
+console.log( me.isCool ); //-> false
+console.log( me.hobbies instanceof DefineList ); //-> true
+```
+@codepen
 
 
-  If the property definition is a Constructor function, it's considered a `Type` setting.
+If the property definition is a Constructor function, it's considered a `Type` setting.
 
-  ```js
-  import {DefineMap} from "can";
+```js
+import {DefineMap} from "can";
 
-  const Address = DefineMap.extend( {
-    zip: "number"
-  } );
-  const Person = DefineMap.extend( {
-    address: Address
-  } );
+const Address = DefineMap.extend( {
+  zip: "number"
+} );
+const Person = DefineMap.extend( {
+  address: Address
+} );
 
-  const me = new Person( { address: { zip: "60048" } } );
-  console.log( me.address.zip ); //-> 60048
-  ```
-  @codepen
+const me = new Person( { address: { zip: "60048" } } );
+console.log( me.address.zip ); //-> 60048
+```
+@codepen
 
-  If the property is an __object__, it's considered to be a [can-define.types.propDefinition].
+If the property is an __object__, it's considered to be a [can-define.types.propDefinition].
 
-  ```js
-  import {DefineMap} from "can";
+```js
+import {DefineMap} from "can";
 
-  const Person = DefineMap.extend( {
-    fullName: {
-      get: function() {
-        return this.first + " " + this.last;
-      },
-      set: function( newVal ) {
-        const parts = newVal.split( " " );
-        this.first = parts[ 0 ];
-        this.last = parts[ 1 ];
-      }
+const Person = DefineMap.extend( {
+  fullName: {
+    get: function() {
+      return this.first + " " + this.last;
     },
-
-    // slick way of creating an 'inline' type.
-    address: {
-      Type: {
-        zip: "number"
-      }
+    set: function( newVal ) {
+      const parts = newVal.split( " " );
+      this.first = parts[ 0 ];
+      this.last = parts[ 1 ];
     }
-  } );
+  },
 
-  const me = new Person( { fullName: "Rami Myer", address: { zip: "60048" } } );
-  console.log( me.first ); //-> "Rami"
-  console.log( me.address.zip ); //-> 60048
-  ```
-  @codepen
+  // slick way of creating an 'inline' type.
+  address: {
+    Type: {
+      zip: "number"
+    }
+  }
+} );
 
-  @return {can-define/map/map} A DefineMap constructor function.
+const me = new Person( { fullName: "Rami Myer", address: { zip: "60048" } } );
+console.log( me.first ); //-> "Rami"
+console.log( me.address.zip ); //-> 60048
+```
+@codepen
+
+@return {can-define/map/map} A DefineMap constructor function.


### PR DESCRIPTION
Fixes a majority of issues in #378

## [can-define/map/map.html](https://canjs.com/doc/can-define/map/map.html)
- [x] codepen-able
- [x] import changed to can

## [map/KeysEvent.html](https://canjs.com/doc/can-define/map/map/KeysEvent.html)
#### Needs:
- [x] codepen
- [x] ES6
- [x] Syntax Highlighting

## [map/PropertyNameEvent.html](https://canjs.com/doc/can-define/map/map/PropertyNameEvent.html)
#### Needs:
- [x] codepen
- [x] ES6
- [x] Syntax Highlighting

## [map/map.extend.html](https://canjs.com/doc/can-define/map/map.extend.html)
- [x] Update to `"can"` import
- [x] Add working examples.

## [map/map.seal.html](https://canjs.com/doc/can-define/map/map.seal.html)
#### Needs:
- [x] codepen

## [map/map.prototype.assign.html](https://canjs.com/doc/can-define/map/map.prototype.assign.html)
#### Needs:
- [x] codepen
- [x] ES6

## [map/map.prototype.assignDeep.html](https://canjs.com/doc/can-define/map/map.prototype.assignDeep.html)
#### Needs:
- [x] codepen
- [x] ES6
- [x] example actually returns `["first", "2", "3"]`.

## [map/map.prototype.deleteKey.html](https://canjs.com/doc/can-define/map/map.prototype.deleteKey.html)
#### Needs:
- [x] codepen
- [x] ES6
- [ ] Better elaboration that it doesn't delete the keys predefined by type because it would also have to delete those getter and setters on other instances. -- *improved*

## [map/map.prototype.forEach.html](https://canjs.com/doc/can-define/map/map.prototype.forEach.html)
#### Needs:
- [x] codepen
- [x] ES6
- [x] Syntax Highlighting
#### Discourse:
- [ ] While this has a Use section it should probably elaborate further what the example is actually doing. -- *improved*

## [map/map.prototype.get.html](https://canjs.com/doc/can-define/map/map.prototype.get.html)
#### Needs:
- [x] codepen
- [x] ES6

## [map/map.prototype.serialize.html](https://canjs.com/doc/can-define/map/map.prototype.serialize.html)
#### Needs:
- [x] codepen
- [x] ES6

## [map/map.prototype.set.html](https://canjs.com/doc/can-define/map/map.prototype.set.html) 
#### Needs:
- [x] Examples

## [map/map.prototype.update.html](https://canjs.com/doc/can-define/map/map.prototype.update.html)
#### Needs:
- [x] codepen
- [x] ES6

## [map/map.prototype.updateDeep.html](https://canjs.com/doc/can-define/map/map.prototype.updateDeep.html)
#### Needs:
- [x] codepen
- [x] ES6

## [map/map.prototype.wildcard.html](https://canjs.com/doc/can-define/map/map.prototype.wildcard.html)
#### Needs:
- [x] Syntax Highlighting
- [x] ES6