### PR TITLE
uses proper defineExpando in instantiation

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -1013,11 +1013,7 @@ define.setup = function(props, sealed) {
 		if(definitions[prop] !== undefined) {
 			map[prop] = value;
 		} else {
-			var def = define.makeSimpleGetterSetter(prop);
-			instanceDefinitions[prop] = {};
-			Object_defineNamedPrototypeProperty(map, prop, def);
-			// possibly convert value to List or DefineMap
-			map[prop] = define.types.observable(value);
+			define.expando(map, prop, value);
 		}
 	});
 	if(canReflect.size(instanceDefinitions) > 0) {
@@ -1033,6 +1029,65 @@ define.setup = function(props, sealed) {
 		}
 	}
 	//!steal-remove-end
+};
+
+
+var returnFirstArg = function(arg){
+	return arg;
+};
+
+define.expando = function(map, prop, value) {
+	if(define._specialKeys[prop]) {
+		// ignores _data and _computed
+		return true;
+	}
+	// first check if it's already a constructor define
+	var constructorDefines = map._define.definitions;
+	if(constructorDefines && constructorDefines[prop]) {
+		return;
+	}
+	// next if it's already on this instances
+	var instanceDefines = map._instanceDefinitions;
+	if(!instanceDefines) {
+		if(Object.isSealed(map)) {
+			return;
+		}
+		Object.defineProperty(map, "_instanceDefinitions", {
+			configurable: true,
+			enumerable: false,
+			writable: true,
+			value: {}
+		});
+		instanceDefines = map._instanceDefinitions;
+	}
+	if(!instanceDefines[prop]) {
+		var defaultDefinition = map._define.defaultDefinition || {type: define.types.observable};
+		define.property(map, prop, defaultDefinition, {},{});
+		// possibly convert value to List or DefineMap
+		if(defaultDefinition.type) {
+			map._data[prop] = define.make.set.type(prop, defaultDefinition.type, returnFirstArg).call(map, value);
+		} else {
+			map._data[prop] = define.types.observable(value);
+		}
+
+		instanceDefines[prop] = defaultDefinition;
+		if(!map.__inSetup) {
+			queues.batch.start();
+			map.dispatch({
+				type: "can.keys",
+				target: map
+			});
+			if(map._data[prop] !== undefined) {
+				map.dispatch({
+					type: prop,
+					target: map,
+					patches: [{type: "set", key: prop, value: map._data[prop]}],
+				},[map._data[prop], undefined]);
+			}
+			queues.batch.stop();
+		}
+		return true;
+	}
 };
 define.replaceWith = defineLazyValue;
 define.eventsProto = eventsProto;

--- a/define-helpers/define-helpers.js
+++ b/define-helpers/define-helpers.js
@@ -5,62 +5,9 @@ var queues = require("can-queues");
 var dev = require("can-log/dev/dev");
 var ensureMeta = require("../ensure-meta");
 
-var returnFirstArg = function(arg){
-	return arg;
-};
 var defineHelpers = {
 	// returns `true` if the value was defined and set
-	defineExpando: function(map, prop, value) {
-		if(define._specialKeys[prop]) {
-			// ignores _data and _computed
-			return true;
-		}
-		// first check if it's already a constructor define
-		var constructorDefines = map._define.definitions;
-		if(constructorDefines && constructorDefines[prop]) {
-			return;
-		}
-		// next if it's already on this instances
-		var instanceDefines = map._instanceDefinitions;
-		if(!instanceDefines) {
-			if(Object.isSealed(map)) {
-				return;
-			}
-			Object.defineProperty(map, "_instanceDefinitions", {
-				configurable: true,
-				enumerable: false,
-				writable: true,
-				value: {}
-			});
-			instanceDefines = map._instanceDefinitions;
-		}
-		if(!instanceDefines[prop]) {
-			var defaultDefinition = map._define.defaultDefinition || {type: define.types.observable};
-			define.property(map, prop, defaultDefinition, {},{});
-			// possibly convert value to List or DefineMap
-			if(defaultDefinition.type) {
-				map._data[prop] = define.make.set.type(prop, defaultDefinition.type, returnFirstArg).call(map, value);
-			} else {
-				map._data[prop] = define.types.observable(value);
-			}
-
-			instanceDefines[prop] = defaultDefinition;
-			queues.batch.start();
-			map.dispatch({
-				type: "can.keys",
-				target: map
-			});
-			if(map._data[prop] !== undefined) {
-				map.dispatch({
-					type: prop,
-					target: map,
-					patches: [{type: "set", key: prop, value: map._data[prop]}],
-				},[map._data[prop], undefined]);
-			}
-			queues.batch.stop();
-			return true;
-		}
-	},
+	defineExpando: define.expando,
 	reflectSerialize: function(unwrapped){
 		var constructorDefinitions = this._define.definitions;
 		var defaultDefinition = this._define.defaultDefinition;

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1426,3 +1426,14 @@ QUnit.test("type called with `this` as the map (#349)", function(){
 	var map = new Type();
 	QUnit.equal(map.foo, 5);
 });
+
+QUnit.test("expandos use default type (#383)", function(){
+	var AllNumbers = DefineMap.extend({
+		"*": {type: "number"}
+	});
+
+	var someNumbers = new AllNumbers({
+		version: "24"
+	});
+	QUnit.ok(someNumbers.version === 24, "is 24");
+});


### PR DESCRIPTION
Fixes #383 

This moves the use of defineExpando to initialization.  This will likely slow up creating a new DefineMap of properties that haven't already been defined.  However, I don't think this is that common of a case.