### PR TITLE
Makes it so "*" and __setup are no longer enumerable properties.

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -929,7 +929,8 @@ getDefinitionsAndMethods = function(defines, baseDefines, typePrototype) {
 		}
 	});
 	if(defaults) {
-		defines["*"] = defaults;
+		// we should move this property off the prototype.
+		defineConfigurableAndNotEnumerable(defines,"*", defaults);
 	}
 	return {definitions: definitions, methods: methods, defaultDefinition: defaultDefinition};
 };

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1437,3 +1437,22 @@ QUnit.test("expandos use default type (#383)", function(){
 	});
 	QUnit.ok(someNumbers.version === 24, "is 24");
 });
+
+QUnit.test("do not enumerate anything other than key properties (#369)", function(){
+	var Type = DefineMap.extend({
+		aProp: "string",
+		aMethod: function(){}
+	});
+
+	var instance = new Type({aProp: "VALUE", anExpando: "VALUE"});
+
+	var props = {};
+	for(var prop in instance) {
+		props[prop] = true;
+	}
+	QUnit.deepEqual(props,{
+		aProp: true,
+		anExpando: true,
+		aMethod: true // TODO: this should be removed someday
+	});
+});

--- a/map/map.js
+++ b/map/map.js
@@ -86,14 +86,13 @@ var DefineMap = Construct.extend("DefineMap",{
 			for(key in DefineMap.prototype) {
 				define.defineConfigurableAndNotEnumerable(prototype, key, prototype[key]);
 			}
-
-			this.prototype.setup = function(props){
+			define.defineConfigurableAndNotEnumerable(prototype, "setup", function(props){
 				define.setup.call(
 					this,
 					props || {},
 					this.constructor.seal
 				);
-			};
+			});
 		} else {
 			for(key in prototype) {
 				define.defineConfigurableAndNotEnumerable(prototype, key, prototype[key]);


### PR DESCRIPTION
partially fixes #369 as methods are still enumerable.  Ultimately can-construct #64 should make functions non-enumerable.