### PR TITLE
Improvements to Can-Define Documentation

### DIFF
--- a/docs/TypeConstructor.md
+++ b/docs/TypeConstructor.md
@@ -78,7 +78,7 @@ value.
 ## Use
 
 ```js
-import {DefineMap} from "can";
+import {DefineMap, Reflect as canReflect} from "can";
 
 const Address = DefineMap.extend( {
     street: "string",
@@ -95,6 +95,7 @@ const direction = new Direction( {
     to: new Address( {street: "123 Greenview", city: "Libertyville"} )
 } );
 
+console.log( direction.from instanceof Address ); //-> true
 console.log( direction.serialize() ); //-> {
 //   from: {city: "Chicago", street: "2060 N. Stave"}
 //   to: {city: "Libertyville", street: "123 Greenview"}

--- a/docs/TypeConstructor.md
+++ b/docs/TypeConstructor.md
@@ -18,7 +18,7 @@ value.
     }
   });
   const ex = new Example();
-  ex.set( "prop", {first: "Justin", last: "Meyer"} );
+  ex.prop = {first: "Justin", last: "Meyer"};
 
   console.log( ex.prop instanceof Person ); //-> true
   console.log( ex.prop.fullName ); //-> "Justin Meyer"

--- a/docs/TypeConstructor.md
+++ b/docs/TypeConstructor.md
@@ -6,75 +6,98 @@ value.
 
 @signature `Type`
 
-A constructor function can be provided that is called to convert incoming values set on this property, like:
+  A constructor function can be provided that is called to convert incoming values set on this property, like:
 
-```js
-{
-	prop: {
-		Type: Person
-	}
-}
-```    
+  ```js
+  import {DefineMap} from "can";
+  import {Person} from "//unpkg.com/can-demo-models@5";
 
-The `Type` constructor is called before the [can-define.types.type] property and before [can-define.types.set]. It checks if the incoming value
-is an [instanceof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) `Type`. If it is, or if it is `null` or `undefined`, it passes the original value through.  If not, it passes the original value to `new Type(originalValue)` and returns the
-new instance to be set.
+  const Example = DefineMap.extend({
+    prop: {
+      Type: Person
+    }
+  });
+  const ex = new Example();
+  ex.set( "prop", {first: "Justin", last: "Meyer"} );
+
+  console.log( ex.prop instanceof Person ); //-> true
+  console.log( ex.prop.fullName ); //-> "Justin Meyer"
+  ```
+  @codepen
+
+  The `Type` constructor is called before the [can-define.types.type] property and before [can-define.types.set]. It checks if the incoming value
+  is an [instanceof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) `Type`. If it is, or if it is `null` or `undefined`, it passes the original value through.  If not, it passes the original value to `new Type(originalValue)` and returns the
+  new instance to be set.
 
 @signature `{propDefinition}`
 
-A [can-define.types.propDefinition] that defines an inline [can-define/map/map] type.  For example:
+  A [can-define.types.propDefinition] that defines an inline [can-define/map/map] type.  For example:
 
-```js
-{
-	address: {
-		Type: {
-			street: "string",
-			city: "string"
-		}
-	}
-}
-```
+  ```js
+  {
+    address: {
+      Type: {
+        street: "string",
+        city: "string"
+      }
+    }
+  }
+  ```
 
 @signature `[Type|propDefinition]`
 
-Defines an inline [can-define/list/list] type that's an array of `Type` or inline [can-define.types.propDefinition] [can-define/map/map]
-instances.  For example:
+  Defines an inline [can-define/list/list] type that's an array of `Type` or inline [can-define.types.propDefinition] [can-define/map/map]
+  instances.  For example:
 
-```js
-{
-	people: {
-		Type: [ Person ]
-	},
-	addresses: {
-		Type: [ {
-			street: "string",
-			city: "string"
-		} ]
-	}
-}
-```
+  ```js
+  import {DefineMap} from "can";
 
+  const List = DefineMap.extend({
+    people: {
+      Type: [ Person ]
+    },
+    addresses: {
+      Type: [ {
+        street: "string",
+        city: "string"
+      } ]
+    }
+  });
+
+  const myList = new List({
+    people: [ {first: "Justin", last: "Meyer"} ],
+    addresses: [ {street: "11 Example Ave.", city: "Chicago"} ]
+  });
+
+  console.log( myList.serialize() );
+  ```
+  @codepen
 
 @body
 
 ## Use
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 
 const Address = DefineMap.extend( {
-	street: "string",
-	city: "string"
+    street: "string",
+    city: {type:"string", default: "Chicago"}
 } );
 
 const Direction = DefineMap.extend( {
-	from: { Type: Address },
-	to: Address
+    from: { Type: Address },
+    to: Address
 } );
 
 const direction = new Direction( {
-	from: { street: "2060 N. Stave", city: "Chicago" },
-	to: new Address( { street: "123 Greenview", city: "Libertyville" } )
+    from: {street: "2060 N. Stave"},
+    to: new Address( {street: "123 Greenview", city: "Libertyville"} )
 } );
+
+console.log( direction.serialize() ); //-> {
+//   from: {city: "Chicago", street: "2060 N. Stave"}
+//   to: {city: "Libertyville", street: "123 Greenview"}
+// }
 ```
 @codepen

--- a/docs/default.md
+++ b/docs/default.md
@@ -58,13 +58,15 @@ The following defaults `age` to `0` and `address` to an object:
 ```js
 import {DefineMap} from "can";
 
-// A default age of `0`:
+
 const Person = DefineMap.extend( {
+  // A default age of `0`:
 	age: {
 		default: 0
 	},
+  // A default address:
 	address: {
-		default: function() {
+		default() {
 			return { city: "Chicago", state: "IL" };
 		}
 	}

--- a/docs/default.md
+++ b/docs/default.md
@@ -6,36 +6,48 @@ is read for the first time.
 
 @signature `default()`
 
-A function can be provided that returns the default value used for this property, like:
+  A function can be provided that returns the default value used for this property, like:
 
-```js
-{
-	prop: {
-		default: function() {
-			return [];
-		}
-	}
-}
-```
+  ```js
+  import {DefineMap} from "can";
 
+  const Example = DefineMap.extend( {
+    prop: {
+      default: function() {
+        return [];
+      }
+    }
+  } );
 
-If the default value should be an object of some type, it should be specified as the return value of a function (the above call signature) so that all instances of this map don't point to the same object.  For example, if the property `value` above had not returned an empty array but instead just specified an array using the next call signature below, all instances of that map would point to the same array (because JavaScript passes objects by reference).
+  const ex = new Example();
+  console.log( ex.prop.serialize() ); //-> []
+  ```
+  @codepen
 
-@return {*} The default value.  This will be passed through setter and type.
+  If the default value should be an object of some type, it should be specified as the return value of a function (the above call signature) so that all instances of this map don't point to the same object.  For example, if the property `value` above had not returned an empty array but instead just specified an array using the next call signature below, all instances of that map would point to the same array (because JavaScript passes objects by reference).
+
+  @return {*} The default value.  This will be passed through setter and type.
 
 @signature `default`
 
-Any value can be provided as the default value used for this property, like:
+  Any value can be provided as the default value used for this property, like:
 
-```js
-{
-	prop: {
-		default: 'foo'
-	}
-}
-```
+  ```js
+  import {DefineMap} from "can"
 
-@param {*} defaultVal The default value, which will be passed through setter and type.
+  const Example = DefineMap.extend( {
+    prop: {
+      default: "foo"
+    }
+  } );
+
+  const ex = new Example();
+  console.log( ex.prop ); //-> "foo"
+
+  ```
+  @codepen
+
+  @param {*} defaultVal The default value, which will be passed through setter and type.
 
 @body
 
@@ -44,7 +56,8 @@ Any value can be provided as the default value used for this property, like:
 The following defaults `age` to `0` and `address` to an object:
 
 ```js
-import { DefineMap } from "can"
+import {DefineMap} from "can";
+
 // A default age of `0`:
 const Person = DefineMap.extend( {
 	age: {
@@ -58,10 +71,11 @@ const Person = DefineMap.extend( {
 } );
 
 const person = new Person();
-console.log(person.age); //-> 0
+console.log( person.age ); //-> 0
+console.log( person.address.serialize() ); //-> { city: "Chicago", state: "IL" }
 ```
 @codepen
 
 ## Alternates
 
-There is a third way to provide a default value, which is explained in the [can-define.types.defaultConstructor] docs page. `default` lowercased is for providing default values for a property type, while `Default` uppercased is for providing a constructor function, which will be invoked with `new` to create a default value for each instance of this map.
+There is a third way to provide a default value, which is explained in the [can-define.types.defaultConstructor] docs page. `default`, lowercase, is for providing default values for a property type, while `[can-define.types.defaultConstructor Default]`, uppercase, is for providing a constructor function, which will be invoked with `new` to create a default value for each instance of this map.

--- a/docs/defaultConstructor.md
+++ b/docs/defaultConstructor.md
@@ -27,7 +27,7 @@ Specify `Default` like:
 ## Use
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 
 const Address = DefineMap.extend( {
 	street: { type: "string", value: "321 Longbow" },

--- a/docs/defaultConstructor.md
+++ b/docs/defaultConstructor.md
@@ -43,7 +43,7 @@ const direction = new Direction( {
 	to: { street: "2070 N. Stave" }
 } );
 
-console.log(direction.from.street); //-> "321 Longbow"
-console.log(direction.to.street);   //-> "2070 N. Stave"
+console.log( direction.from.street ); //-> "321 Longbow"
+console.log( direction.to.street );   //-> "2070 N. Stave"
 ```
 @codepen

--- a/docs/defaultConstructor.md
+++ b/docs/defaultConstructor.md
@@ -5,22 +5,22 @@ Provides a constructor function to be used to provide a default value for a prop
 
 @signature `Default`
 
-A constructor function can be provided that is called to create a default value used for this property.
-This constructor will be invoked with `new` for each created instance. The default
-value is created on demand when the property is read for the first time.
+  A constructor function can be provided that is called to create a default value used for this property.
+  This constructor will be invoked with `new` for each created instance. The default
+  value is created on demand when the property is read for the first time.
 
-Specify `Default` like:
+  Specify `Default` like:
 
-```js
-{
-	prop: {
-		Default: Array
-	},
-	person: {
-		Default: Person
-	}
-}
-```
+  ```js
+  {
+    prop: {
+      Default: Array
+    },
+    person: {
+      Default: Person
+    }
+  }
+  ```
 
 @body
 

--- a/docs/define.md
+++ b/docs/define.md
@@ -35,7 +35,7 @@ and [can-define/list/list] are documented here.
   	message: { type: "string" }
   } );
 
-  var greeting = new Greeting("Hello");
+  const greeting = new Greeting("Hello");
 
   canReflect.onKeyValue(greeting, "message", (newValue) => {
 	  console.log(newValue); // logs "goodbye"
@@ -80,8 +80,7 @@ more assumptions on the type constructor.  `can-define` can be used
 to create completely customized types.
 
 
-The following creates a
-`Person` constructor function that
+The following creates a `Person` constructor function that
 will be used to create `Person` instances with observable properties:
 
 ```js
@@ -105,13 +104,13 @@ define( Person.prototype, {
 // Create an instance
 const person = new Person( "Justin", "Meyer" );
 
-console.log( person.first )    //-> "Justin"
-console.log( person.last )     //-> "Meyer"
-console.log( person.fullName ) //-> "Justin Meyer"
+console.log( person.first ); //-> "Justin"
+console.log( person.last ); //-> "Meyer"
+console.log( person.fullName ); //-> "Justin Meyer"
 
 person.on( "fullName", function( ev, newVal, oldVal ) {
-	console.log( newVal ) //-> "Ramiya Meyer"
-	console.log( oldVal ) //-> "Justin Meyer"
+	console.log( newVal ); //-> "Ramiya Meyer"
+	console.log( oldVal ); //-> "Justin Meyer"
 } );
 
 person.first = "Ramiya";

--- a/docs/define.md
+++ b/docs/define.md
@@ -38,33 +38,32 @@ and [can-define/list/list] are documented here.
   const greeting = new Greeting("Hello");
 
   canReflect.onKeyValue(greeting, "message", (newValue) => {
-  	console.log(newValue.target.message); //-> logs "goodbye"
+  	console.log( newValue.target.message ); //-> logs "goodbye"
   });
 
   greeting.message = "goodbye";
   ```
   @codepen
 
-@param {Object} prototype The prototype object of a constructor function or [class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/class). The prototype object will have getter/setters defined on it that carry out the defined behavior.  The prototype will also contain all of [can-event-queue/map/map]'s methods.
+  @param {Object} prototype The prototype object of a constructor function or [class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/class). The prototype object will have getter/setters defined on it that carry out the defined behavior.  The prototype will also contain all of [can-event-queue/map/map]'s methods.
 
-@param {Object<String,can-define.types.propDefinition>} propDefinitions An object of properties and their definitions. For example, a property (`propertyName`) has a [can-define.types.propDefinition] object with zero or more of the following behaviors:
+  @param {Object<String,can-define.types.propDefinition>} propDefinitions An object of properties and their definitions. For example, a property (`propertyName`) has a [can-define.types.propDefinition] object with zero or more of the following behaviors:
 
-```js
-define(Type.prototype, {
+  ```js
+  define(Type.prototype, {
     propertyName: {
-        default: function() { /* ... */ },
-        Default: Constructor,
-        type: function() { /* ... */ },
-        Type: Constructor,
-        get: function() { /* ... */ },
-        value: function() { /* ... */ },
-        set: function() { /* ... */ },
-        serialize: function() { /* ... */ },
-        identity: Boolean
+      default: function() { /* ... */ },
+      Default: Constructor,
+      type: function() { /* ... */ },
+      Type: Constructor,
+      get: function() { /* ... */ },
+      value: function() { /* ... */ },
+      set: function() { /* ... */ },
+      serialize: function() { /* ... */ },
+      identity: Boolean
     }
-})
-```
-
+  })
+  ```
 
 @body
 

--- a/docs/define.md
+++ b/docs/define.md
@@ -38,19 +38,16 @@ and [can-define/list/list] are documented here.
   const greeting = new Greeting("Hello");
 
   canReflect.onKeyValue(greeting, "message", (newValue) => {
-	  console.log(newValue); // logs "goodbye"
+  	console.log(newValue.target.message); //-> logs "goodbye"
   });
 
   greeting.message = "goodbye";
   ```
   @codepen
 
-@param {Object} prototype The prototype object of a constructor function or [class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/class). The prototype
-object will have getter/setters defined on it that carry out the defined behavior.  The prototype will also contain
-all of [can-event-queue/map/map]'s methods.
+@param {Object} prototype The prototype object of a constructor function or [class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/class). The prototype object will have getter/setters defined on it that carry out the defined behavior.  The prototype will also contain all of [can-event-queue/map/map]'s methods.
 
-@param {Object<String,can-define.types.propDefinition>} propDefinitions An object of
-properties and their definitions. For example, a property (`propertyName`) has a [can-define.types.propDefinition] object with zero or more of the following behaviors:
+@param {Object<String,can-define.types.propDefinition>} propDefinitions An object of properties and their definitions. For example, a property (`propertyName`) has a [can-define.types.propDefinition] object with zero or more of the following behaviors:
 
 ```js
 define(Type.prototype, {

--- a/docs/define.types.md
+++ b/docs/define.types.md
@@ -48,9 +48,9 @@ const Person = DefineMap.extend( {
 	age: "number"
 } );
 
-var person = new Person({age: "30"});
+const person = new Person( {age: "30"} );
 
-console.log(person.age) //-> 30
+console.log( person.age ); //-> 30
 ```
 @codepen
 
@@ -64,9 +64,9 @@ const Person = DefineMap.extend( {
 	age: define.types.number
 } );
 
-var person = new Person({age: "30"});
+const person = new Person( {age: "30"} );
 
-console.log(person.age) //-> 30
+console.log( person.age ); //-> 30
 ```
 @codepen
 
@@ -80,8 +80,8 @@ const Person = DefineMap.extend( {
 	age: MaybeNumber
 } );
 
-var person = new Person({age: "30"});
+const person = new Person({age: "30"});
 
-console.log(person.age) //-> 30
+console.log( person.age ); //-> 30
 ```
 @codepen

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -5,14 +5,14 @@ Specifies that the property uniquely identifies instances of the type.
 
 @type {Boolean}
 
-If `true`, specifies that the property uniquely identifies instances of the
-type.  `identity` configures the result of [can-reflect.getIdentity].
+  If `true`, specifies that the property uniquely identifies instances of the
+  type.  `identity` configures the result of [can-reflect.getIdentity].
 
-The following specifies that the `id` property values uniquely identifies `Todo`
-instances:
+  The following specifies that the `id` property values uniquely identifies `Todo`
+  instances:
 
   ```js
-  import { DefineMap, Reflect } from "can";
+  import {DefineMap, Reflect as canReflect} from "can";
 
   const Todo = DefineMap.extend("Todo",{
       id: {type: "number", identity: true},
@@ -22,15 +22,15 @@ instances:
 
   const todo = new Todo({id: 6, name: "mow lawn"});
 
-  console.log(Reflect.getIdentity(todo)); //-> 6
+  console.log( canReflect.getIdentity(todo) ); //-> 6
   ```
   @codepen
 
-`identity` can be `true` for multiple properties. If multiple identity properties
-are specified, a sorted JSON string is returned:
+  `identity` can be `true` for multiple properties. If multiple identity properties
+  are specified, a sorted JSON string is returned:
 
   ```js
-  import { DefineMap, Reflect } from "can";
+  import {DefineMap, Reflect as canReflect} from "can";
 
   const Grade = DefineMap.extend("Grade",{
       classId: {type: "number", identity: true},
@@ -40,7 +40,7 @@ are specified, a sorted JSON string is returned:
 
   const grade = new Grade({classId: 5, studentId: 7, grade: "A+"});
 
-  console.log(Reflect.getIdentity(grade)); //-> '{"classId":5,"studentId":7}'
+  console.log( canReflect.getIdentity(grade) ); //-> "{'classId':5,'studentId':7}"
   ```
   @codepen
 

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -20,7 +20,7 @@ instances:
       complete: "boolean"
   });
 
-  var todo = new Todo({id: 6, name: "mow lawn"});
+  const todo = new Todo({id: 6, name: "mow lawn"});
 
   console.log(Reflect.getIdentity(todo)); //-> 6
   ```
@@ -38,7 +38,7 @@ are specified, a sorted JSON string is returned:
       grade: "string"
   });
 
-  var grade = new Grade({classId: 5, studentId: 7, grade: "A+"});
+  const grade = new Grade({classId: 5, studentId: 7, grade: "A+"});
 
   console.log(Reflect.getIdentity(grade)); //-> '{"classId":5,"studentId":7}'
   ```

--- a/docs/serialize.md
+++ b/docs/serialize.md
@@ -45,7 +45,7 @@ Defines custom serialization behavior for a property.
 
 @signature `serialize( currentValue, propertyName )`
 
-	Specifies the serialized value of a property.
+  Specifies the serialized value of a property.
 
   ```js
   import {DefineMap} from "can";

--- a/docs/serialize.md
+++ b/docs/serialize.md
@@ -5,38 +5,71 @@ Defines custom serialization behavior for a property.
 
 @signature `Boolean`
 
-Specifies if the property should be serialized.  By default, all properties except for
-ones with defined [can-define.types.get getters] are serialized. Prevent a property
-from being serialized like:
+  Specifies if the property should be serialized.  By default, all properties except for
+  ones with defined [can-define.types.get getters] are serialized. Prevent a property
+  from being serialized like:
 
-```js
-{
-	propertyName: {
-		serialize: false
-	}
-}
-```
+  ```js
+  import {DefineMap} from "can";
 
-Make a [can-define.types.get getter] property part of the serialized result like:
+  const myMap = DefineMap.extend({
+    propertyName: {
+      serialize: false
+    },
+    secondPropertyName: "string"
+  });
 
-```js
-{
-	propertyName: {
-		get: function() { /* ... */ },
-		serialize: true
-	}
-}
-```
+  const map = new myMap({ propertyName: "foobar", secondPropertyName: "bar" });
+
+  console.log( map.serialize() ); //-> {secondPropertyName: "bar"}
+  ```
+  @codepen
+
+  Make a [can-define.types.get getter] property part of the serialized result like:
+
+  ```js
+  import {DefineMap} from "can";
+
+  const myMap = DefineMap.extend({
+    propertyName: {
+      get() { return "test"; },
+      serialize: true
+    }
+  });
+
+  const map = new myMap();
+
+  console.log( map.serialize() ); //-> { propertyName: "test" }
+  ```
+  @codepen
 
 @signature `serialize( currentValue, propertyName )`
 
-Specifies the serialized value of a property.
+	Specifies the serialized value of a property.
 
-@param {*} currentValue The current value of the attribute.
+  ```js
+  import {DefineMap} from "can";
 
-@param {String} propertyName The name of the property being serialized.
+  const myMap = DefineMap.extend({
+    example: {
+      serialize( currentValue, propertyName ) {
+        console.log( currentValue ); //-> "Value"
+        console.log( propertyName ); //-> "example"
+      }
+    }
+  });
+  
+  const map = new myMap({ example: "Value" });
 
-@return {*|undefined} If `undefined` is returned, the value is not serialized.
+  map.serialize();
+  ```
+  @codepen
+
+	@param {*} currentValue The current value of the attribute.
+
+	@param {String} propertyName The name of the property being serialized.
+
+	@return {*|undefined} If `undefined` is returned, the value is not serialized.
 
 @body
 
@@ -57,32 +90,46 @@ The following causes a locationIds property to be serialized into
 the comma separated ID values of the location property on this instance:
 
 ```js
-{
+import {DefineMap} from "can";
+
+const myMap = DefineMap.extend({
+  locations: [],
 	locationIds: {
-		serialize: function() {
-			return this.locations.map( function( location ) {
-				ids.push( location.id );
+		serialize() {
+			return this.locations.map( ( location ) => {
+				return location.id;
 			} ).join( "," );
 		}
 	}
-}
+});
+const map = new myMap({
+  locations: [{id: 1}, {id: 2}, {id: 3}]
+});
+
+console.log( map.serialize().locationIds ); //-> "1,2,3"
 ```
+@codepen
 
 Returning `undefined` for any property means this property will not be part of the serialized
 object.  For example, if the property numPages is not greater than zero, the following example
 won't include it in the serialized object.
 
 ```js
-{
-	prop: {
-		numPages: {
-			serialize: function( num ) {
-				if ( num <= 0 ) {
-					return undefined;
-				}
-				return num;
-			}
-		}
-	}
-}
+import {DefineMap} from "can";
+
+const myBook = DefineMap.extend({
+  prop: {
+    serialize: function( num ) {
+      if ( num <= 0 ) {
+          return undefined;
+      }
+      return num;
+    }
+  },
+  bar: "string"
+});
+const book = new myBook({ prop: -5, bar: "foo" });
+
+console.log( book.serialize() ); //-> { bar: "foo" }
 ```
+@codepen

--- a/docs/type.md
+++ b/docs/type.md
@@ -130,33 +130,3 @@ console.log( map.locations instanceof DefineList ); //-> false
 console.log( Array.isArray( map.locations ) ); //-> true
 ```
 @codepen
-
-### Working with the 'compute' type
-
-Setting type as `compute` allows for resolving a computed property with the .attr()
-method.
-
-```js
-import {DefineMap, SimpleObservable, Reflect as canReflect} from "can";
-
-const MyMap = DefineMap.extend({
-    value: {
-        type: "observable"
-    }
-});
-
-const myMap = new MyMap();
-const c = new SimpleObservable(5);
-
-myMap.value = c;
-console.log( canReflect.getValue(myMap.value) ); //-> 5
-
-canReflect.setValue(c, 6)
-console.log( canReflect.getValue(myMap.value) ); //-> 6
-
-//Be sure if setting to pass the new compute
-const c2 = new SimpleObservable("a");
-myMap.value = c2;
-console.log( canReflect.getValue(myMap.value) ); //-> "a"
-```
-@codepen

--- a/docs/type.md
+++ b/docs/type.md
@@ -95,7 +95,7 @@ import { DefineMap } from "can";
 const Map = DefineMap.extend( {
 	count: { type: "number" },
 	items: {
-		type: function( newValue ) {
+		type( newValue ) {
 			if ( typeof newValue === "string" ) {
 				return newValue.split( "," );
 			} else if ( Array.isArray( newValue ) ) {
@@ -116,15 +116,20 @@ console.log(map.count, map.items); //-> 4 ["1", "2", "3"]
 
 When an array value is set, it is automatically converted into a DefineList. Likewise, objects are converted into DefineMap instances. This behavior can be prevented like the following:
 
-	```js
-  locations: {type: "any"}
-	```
+In this example when a user tries to set the `locations` property, the resulting value will remain an array.
+```js
+import {DefineMap, DefineList} from "can";
 
-When a user tries to set this property, the resulting value will remain an array.
+const MyMap = DefineMap.extend({
+	locations: {type: "any"},
+});
+const map = new MyMap( {locations: [1, 2, 3]} );
 
-	```js
-  map.locations = [1, 2, 3]; // locations is an array, not a DefineList
-	```
+// locations is an array, not a DefineList
+console.log( map.locations instanceof DefineList ); //-> false
+console.log( Array.isArray( map.locations ) ); //-> true
+```
+@codepen
 
 ### Working with the 'compute' type
 
@@ -132,27 +137,26 @@ Setting type as `compute` allows for resolving a computed property with the .att
 method.
 
 ```js
-import {DefineMap} from "can";
+import {DefineMap, SimpleObservable, Reflect as canReflect} from "can";
 
 const MyMap = DefineMap.extend({
     value: {
-        type: "compute"
+        type: "observable"
     }
 });
 
 const myMap = new MyMap();
-const c = compute(5);
+const c = new SimpleObservable(5);
 
 myMap.value = c;
-console.log( myMap.value ); //-> 5
+console.log( canReflect.getValue(myMap.value) ); //-> 5
 
-c(6);
-console.log( myMap.value ); //-> 6
+canReflect.setValue(c, 6)
+console.log( canReflect.getValue(myMap.value) ); //-> 6
 
 //Be sure if setting to pass the new compute
-const c2 = compute("a");
+const c2 = new SimpleObservable("a");
 myMap.value = c2;
-console.log( myMap.value ); //-> "a"
+console.log( canReflect.getValue(myMap.value) ); //-> "a"
 ```
-<!-- `compute` is undefined -->
-<!-- @codepen -->
+@codepen

--- a/docs/type.md
+++ b/docs/type.md
@@ -116,13 +116,15 @@ console.log(map.count, map.items); //-> 4 ["1", "2", "3"]
 
 When an array value is set, it is automatically converted into a DefineList. Likewise, objects are converted into DefineMap instances. This behavior can be prevented like the following:
 
-
-     locations: {type: "any"}
-
+	```js
+  locations: {type: "any"}
+	```
 
 When a user tries to set this property, the resulting value will remain an array.
 
-    map.locations = [1, 2, 3]; // locations is an array, not a DefineList
+	```js
+  map.locations = [1, 2, 3]; // locations is an array, not a DefineList
+	```
 
 ### Working with the 'compute' type
 
@@ -130,7 +132,7 @@ Setting type as `compute` allows for resolving a computed property with the .att
 method.
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 
 const MyMap = DefineMap.extend({
     value: {
@@ -142,15 +144,15 @@ const myMap = new MyMap();
 const c = compute(5);
 
 myMap.value = c;
-console.log(myMap.value); //-> 5
+console.log( myMap.value ); //-> 5
 
 c(6);
-console.log(myMap.value); //-> 6
+console.log( myMap.value ); //-> 6
 
 //Be sure if setting to pass the new compute
 const c2 = compute("a");
 myMap.value = c2;
-console.log(myMap.value); //-> "a"
+console.log( myMap.value ); //-> "a"
 ```
 <!-- `compute` is undefined -->
 <!-- @codepen -->

--- a/docs/type.md
+++ b/docs/type.md
@@ -101,10 +101,13 @@ Converts a value set on an instance into an appropriate value.
 
   const myList = new List({
     people: [ {first: "Justin", last: "Meyer"} ],
-    addresses: [ {street: "11 Example Ave.", city: "Chigago"} ]
+    addresses: [ {street: "11 Example Ave.", city: "Chicago"} ]
   });
 
-  console.log( myList.serialize() );
+  console.log( myList.serialize() ); //-> {
+  //   addresses: [ {city: "Chicago", street: "11 Example Ave."} ],
+  //   people: [ {first: "Justin", last: "Meyer"} ]
+  // }
   ```
   @codepen
 

--- a/docs/type.md
+++ b/docs/type.md
@@ -20,7 +20,7 @@ Converts a value set on an instance into an appropriate value.
   });
 
   const p = new Person();
-  p.set("age", "25");
+  p.age = "25";
   console.log( "p.age is a", typeof p.age, "The value is", p.age ); //-> "p.age is a number. The value is 25"
   ```
   @codepen

--- a/docs/type.md
+++ b/docs/type.md
@@ -5,18 +5,25 @@ Converts a value set on an instance into an appropriate value.
 
 @signature `type(newValue, propertyName)`
 
-Given the set value, transform it into a value appropriate to be set.
-`type` is called before [can-define.types.set].  
+  Given the set value, transform it into a value appropriate to be set.
+  `type` is called before [can-define.types.set].  
 
-```js
-{
-	age: {
-		type: function( newValue, propertyName ) {
-			return +newValue;
-		}
-	}
-}
-```
+  ```js
+  import {DefineMap} from "can";
+
+  const Person = DefineMap.extend({
+    age: {
+      type: ( newValue, propertyName ) => {
+        return +newValue;
+      }
+    }
+  });
+
+  const p = new Person();
+  p.set("age", "25");
+  console.log( "p.age is a", typeof p.age, "The value is", p.age ); //-> "p.age is a number. The value is 25"
+  ```
+  @codepen
 
   @param {*} newValue The value set on the property.
   @param {String} propertyName The property name being set.
@@ -25,53 +32,81 @@ Given the set value, transform it into a value appropriate to be set.
 
 @signature `"typeName"`
 
-Sets the type to a named type in [can-define.types].  The default typeName is `"observable"`.
+  Sets the type to a named type in [can-define.types].  The default typeName is `"observable"`.
 
-```js
-{
-	age: {
-		type: "number"
-	}
-}
-```
+  ```js
+  import {DefineMap} from "can";
+
+  const Person = DefineMap.extend({
+    age: {
+      type: "number"
+    }
+  });
+
+  const p = new Person({ age: "5" });
+
+  console.log( p.age ) //-> 5
+  ```
+  @codepen
 
   @param {String} typeName A named type in [can-define.types].
 
 
-  @signature `{propDefinition}`
+@signature `{propDefinition}`
 
   A [can-define.types.propDefinition] that defines an inline [can-define/map/map] type.  For example:
 
   ```js
-{
-	address: {
-		type: {
-			street: "string",
-			city: "string"
-		}
-	}
-}
-```
+  import {DefineMap} from "can";
 
-  @signature `[Type|propDefinition]`
+  const Home = DefineMap.extend({
+    address: {
+      type: {
+        street: "string",
+        city: { type: "string", default: "Chicago" }
+      }
+    }
+  });
+
+  const myHouse = new Home({
+    address: {
+      street: "101 Example St."
+    }
+  });
+
+  console.log( myHouse.serialize() ); //-> { address: {city: "Chicago", street: "101 Example St."} }
+  ```
+  @codepen
+
+@signature `[Type|propDefinition]`
 
   Defines an inline [can-define/list/list] type that's an array of `Type` or inline `propDefinition` [can-define/map/map]
   instances.  For example:
 
-```js
-{
-	people: {
-		type: [ Person ]
-	},
-	addresses: {
-		type: [ {
-			street: "string",
-			city: "string"
-		} ]
-	}
-}
-```
+  ```js
+  import {DefineMap} from "can";
+  import {Person} from "//unpkg.com/can-demo-models@5";
 
+  const List = DefineMap.extend({
+    people: {
+      type: [ Person ]
+    },
+    addresses: {
+      type: [ {
+        street: "string",
+        city: "string"
+      } ]
+    }
+  });
+
+  const myList = new List({
+    people: [ {first: "Justin", last: "Meyer"} ],
+    addresses: [ {street: "11 Example Ave.", city: "Chigago"} ]
+  });
+
+  console.log( myList.serialize() );
+  ```
+  @codepen
 
 @body
 
@@ -90,7 +125,7 @@ as either:
 The following example converts the `count` property to a number and the `items` property to an array.
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 
 const Map = DefineMap.extend( {
 	count: { type: "number" },

--- a/docs/types.get.md
+++ b/docs/types.get.md
@@ -175,11 +175,11 @@ of the compute.
 import { DefineMap, SimpleObservable, Reflect } from "can";
 
 const MyMap = DefineMap.extend( {
-    value: {
-        get: function( lastSetValue ) {
-            return lastSetValue.value;
-        }
-    }
+	value: {
+		get: function( lastSetValue ) {
+			return lastSetValue.value;
+		}
+	}
 } );
 
 const map = new MyMap();

--- a/docs/types.propDefinition.md
+++ b/docs/types.propDefinition.md
@@ -78,8 +78,8 @@ observable property.  These behaviors can be specified with as an `Object`, `Str
     }
   } );
 
-  const person = new Person({ age: "20", hobbies: "1,2,3" });
-  console.log( person.age, person.hobbies ); //-> 20, ["1", "2", "3"]
+  const person = new Person({ age: "20", hobbies: "basketball,billiards,dancing" });
+  console.log( person.age, person.hobbies ); //-> 20, ["basketball", "billiards", "dancing"]
   ```
   @codepen
 

--- a/docs/types.propDefinition.md
+++ b/docs/types.propDefinition.md
@@ -269,10 +269,22 @@ observable property.  These behaviors can be specified with as an `Object`, `Str
   For example:
 
   ```js
-  {
+  import {DefineMap} from "can";
+
+  const User = DefineMap.extend( {username: "string", password: "string"} );
+  const TodoList = DefineMap.extend( {
     users: [ User ],
     todos: [ { complete: "boolean", name: "string" } ]
-  }
+  } );
+
+  const user1 = new User( {username: "JMeyers", password: "12345"} );
+  const user2 = new User( {username: "PStrozak", password: "54321"} );
+  const myList = new TodoList( {
+    users: [ user1, user2 ],
+    todos: [ {complete: true, name: "Write this example"} ]
+  } );
+
+  console.log( myList.serialize() );
   ```
 
 @type {GETTER} Defines a property's [can-define.types.get] behavior with the

--- a/docs/types.propDefinition.md
+++ b/docs/types.propDefinition.md
@@ -23,299 +23,356 @@ observable property.  These behaviors can be specified with as an `Object`, `Str
 }
 ```
 
-    @option {can-define.types.default} default Specifies the initial value of the property or a function that returns the initial value.
+@option {can-define.types.default} default Specifies the initial value of the property or a function that returns the initial value.
 
-    ```js
-    import { DefineMap } from "can";
-    
-    // A default age of `0`:
-    const Person = DefineMap.extend( {
-        age: {
-            default: 0
-        },
-        address: {
-            default: function() {
-                return { city: "Chicago", state: "IL" };
-            }
+  ```js
+  import {DefineMap} from "can";
+
+  // A default age of `0`:
+  const Person = DefineMap.extend( {
+      age: {
+          default: 0
+      },
+      address: {
+          default: function() {
+              return { city: "Chicago", state: "IL" };
+          }
+      }
+  } );
+
+  const person = new Person();
+  console.log( person.age ); //->  0
+  ```
+  @codepen
+
+@option {can-define.types.defaultConstructor} Default Specifies a function that will be called with `new` whose result is set as the initial value of the attribute.
+
+  ```js
+  import {DefineMap, DefineList} from "can";
+
+  // A default empty DefineList of hobbies:
+  const Person = DefineMap.extend( {
+    hobbies: { Default: DefineList }
+  } );
+
+  const person = new Person();
+  console.log( person.hobbies instanceof DefineList ); //-> true
+  ```
+  @codepen
+
+@option {can-define.types.type} type Specifies the type of the property. The type can be specified as either a function that returns the type coerced value or one of the [can-define.types] names.
+
+  ```js
+  import {DefineMap} from "can";
+
+  const Person = DefineMap.extend( {
+    age: { type: "number" },
+    hobbies: {
+      type: function( newValue ) {
+        if ( typeof newValue === "string" ) {
+          return newValue.split( "," );
+        } else if ( Array.isArray( newValue ) ) {
+          return newValue;
         }
-    } );
-    
-    const person = new Person();
-    console.log(person.age); //->  0
-    ```
-
-    @option {can-define.types.defaultConstructor} Default Specifies a function that will be called with `new` whose result is set as the initial value of the attribute.
-
-    ```js
-import { DefineMap, DefineList } from "can";
-
-// A default empty DefineList of hobbies:
-const Person = DefineMap.extend( {
-	hobbies: { Default: DefineList }
-} );
-
-const person = new Person();
-console.log(person.hobbies); //-> []
-```
-
-    @option {can-define.types.type} type Specifies the type of the property. The type can be specified as either a function that returns the type coerced value or one of the [can-define.types] names.
-
-    ```js
-import { DefineMap } from "can";
-
-const Person = DefineMap.extend( {
-	age: { type: "number" },
-	hobbies: {
-		type: function( newValue ) {
-			if ( typeof newValue === "string" ) {
-				return newValue.split( "," );
-			} else if ( Array.isArray( newValue ) ) {
-				return newValue;
-			}
-		}
-	}
-} );
-
-const person = new Person({ age: 20, hobbies: "1,2,3" });
-console.log(person.age, person.hobbies); //-> 20, [1,2,3]
-```
-
-    @option {can-define.types.typeConstructor} Type A constructor function that takes the assigned property value as the first argument and called with new. For example, the following will call `new Address(newValue)` with whatever non null, undefined, or address type is set as a `Person`'s address property.
-
-    ```js
-import { DefineMap } from "can";
-
-const Address = DefineMap.extend( {
-	street: "string",
-	state: "string"
-} );
-
-const Person = DefineMap.extend( {
-	address: { Type: Address }
-} );
-
-const person = new Person({
-    address: {
-        street: "Example Ave.",
-        state: "IL"
+      }
     }
-});
-console.log(person.address.street); //-> "Example Ave."
-```
+  } );
 
-    @option {can-define.types.get} get A function that specifies how the value is retrieved.  The get function is converted to an [can-compute.async async compute].  It should derive its value from other values on the object. The following defines a `page` getter that reads from a map's offset and limit:
+  const person = new Person({ age: "20", hobbies: "1,2,3" });
+  console.log( person.age, person.hobbies ); //-> 20, ["1", "2", "3"]
+  ```
+  @codepen
 
-    ```js
-import { DefineMap } from "can";
+@option {can-define.types.typeConstructor} Type A constructor function that takes the assigned property value as the first argument and called with new. For example, the following will call `new Address(newValue)` with whatever non null, undefined, or address type is set as a `Person`'s address property.
 
-const pages = DefineMap.extend( {
-    offset: 10,
-    limit: 5,
-	page: {
-		get: function( newVal ) {
-			return Math.floor( this.offset / this.limit ) + 1;
-		}
-	}
-} );
+  ```js
+  import {DefineMap} from "can";
 
-console.log(pages.page) //-> 3
-```
+  const Address = DefineMap.extend( {
+    street: "string",
+    state: "string"
+  } );
 
-    A `get` definition makes the property __computed__ which means it will not be enumerable by default.
+  const Person = DefineMap.extend( {
+    address: { Type: Address }
+  } );
 
-    @option {can-define.types.value} value A function that listens to events and resolves the value of the
-    property.  This should be used when [can-define.types.get] is unable to model the right behavior. The following
-    counts the number of times the `page` property changes:
+  const person = new Person({
+      address: {
+          street: "Example Ave.",
+          state: "IL"
+      }
+  });
+  console.log( person.address.serialize() ); //-> {state: "IL", street: "Example Ave."}
+  ```
+  @codepen
 
-    ```js
-import { DefineMap } from "can";
+@option {can-define.types.get} get A function that specifies how the value is retrieved.  The get function is converted to an [can-compute.async async compute].  It should derive its value from other values on the object. The following defines a `page` getter that reads from a map's offset and limit:
 
-const book = DefineMap.extend( {
-	pageChangeCount: function( prop ) {
-		let count = 0;
+  ```js
+  import {DefineMap} from "can";
 
-		// When page changes, update the count.
-		prop.listenTo( "page", function() {
-			prop.resolve( ++count );
-		} );
+  const Book = DefineMap.extend( {
+    offset: "number",
+    limit: "number",
+    page: {
+      get: function( newVal ) {
+        return Math.floor( this.offset / this.limit ) + 1;
+      }
+    }
+  } );
 
-		// Set initial count.
-		prop.resolve( count );
-	}
-} );
-book.page = 1;
-book.page += 1;
-console.log(book.count); //-> 2
-```
+  const book = new Book( {offset: 10, limit: 5} );
 
-    A `value` definition makes the property __computed__ which means it will not be enumerable by default.
+  console.log( book.page ) //-> 3
+  ```
+  @codepen
 
-    @option {can-define.types.set} set A set function that specifies what should happen when a property is set. `set` is called with the result of `type` or `Type`. The following defines a `page` setter that updates the map's offset:
+  A `get` definition makes the property __computed__ which means it will not be enumerable by default.
 
-    ```js
-DefineMap.extend( {
-	page: {
-		set: function( newVal ) {
-			this.offset = ( parseInt( newVal ) - 1 ) * this.limit;
-		}
-	}
-} );
-```
+@option {can-define.types.value} value A function that listens to events and resolves the value of the property.  This should be used when [can-define.types.get] is unable to model the right behavior. The following counts the number of times the `page` property changes:
 
-    @option {can-define.types.serialize} serialize Specifies the behavior of the property when [can-define/map/map::serialize serialize] is called.
+  ```js
+  import {DefineMap} from "can";
 
-    By default, serialize does not include computed values. Properties with a `get` definition
-    are computed and therefore are not added to the result.  Non-computed properties values are
-    serialized if possible and added to the result.
+  const book = DefineMap.extend( {
+    page: "number",
+    pageChangeCount: function( prop ) {
+      let count = 0;
 
-    ```js
-const Todo = DefineMap.extend( {
-	date: {
-		type: "date",
-		serialize: function( value ) {
-			return value.getTime();
-		}
-	}
-} );
-```
+      // When page changes, update the count.
+      prop.listenTo( "page", function() {
+        prop.resolve( ++count );
+      } );
 
-    @option {can-define.types.identity} identity Specifies the property that uniquely identifies instances of the type.
+      // Set initial count.
+      prop.resolve( count );
+    }
+  } );
+  book.page = 1;
+  book.page += 1;
+  console.log( book.count ); //-> 2
+  ```
+  <!-- @codepen -->
 
-    ```js
-const Grade = DefineMap.extend("Grade",{
-	classId: {type: "number", identity: true},
-	studentId: {type: "number", identity: true},
-	grade: "string"
-});
-```
+  A `value` definition makes the property __computed__ which means it will not be enumerable by default.
+
+@option {can-define.types.set} set A set function that specifies what should happen when a property is set. `set` is called with the result of `type` or `Type`. The following defines a `page` setter that updates the map's offset:
+
+  ```js
+  import {DefineMap} from "can";
+
+  const Book = DefineMap.extend( {
+    offset: "number",
+    limit: "number",
+    page: {
+      set: function( newVal ) {
+        this.offset = ( parseInt( newVal ) - 1 ) * this.limit;
+      }
+    }
+  } );
+
+  const book = new Book({ limit: 5 });
+  book.page = 10;
+  console.log( book.offset ); //-> 45
+  ```
+  @codepen
+
+@option {can-define.types.serialize} serialize Specifies the behavior of the property when [can-define/map/map::serialize serialize] is called.
+
+  By default, serialize does not include computed values. Properties with a `get` definition
+  are computed and therefore are not added to the result.  Non-computed properties values are
+  serialized if possible and added to the result.
+
+  ```js
+  import {DefineMap} from "can";
+
+  const Todo = DefineMap.extend( {
+    date: {
+      type: "date",
+      serialize: function( value ) {
+        return value.getTime();
+      }
+    }
+  } );
+
+  const todo = new Todo( {date: Date.now()} );
+  console.log( todo.serialize() ); //-> {date: 1535751516915}
+  ```
+  @codepen
+
+@option {can-define.types.identity} identity Specifies the property that uniquely identifies instances of the type.
+
+  ```js
+  import {DefineMap, Reflect} from "can";
+
+  const Grade = DefineMap.extend( "Grade", {
+    classId: {type: "number", identity: true},
+    studentId: {type: "number", identity: true},
+    grade: "string"
+  } );
+
+  const myGrade = new Grade( {classId: 12345, studentId: 54321, grade: "A+"} )
+  console.log(Reflect.getIdentity(myGrade)); //-> "{'classId':12345,'studentId':54321}"
+  ```
+  @codepen
 
 @type {String} Defines a [can-define.types.type] converter as one of the named types in [can-define.types].
 
-```js
-{
-	propertyName: "typeName"
-}
-```
+  ```js
+  {
+    propertyName: "typeName"
+  }
+  ```
 
-@type {Constructor} Either creates a method or Defines a [can-define.types.typeConstructor Type] setting with a constructor function.  Constructor functions are identified with [can-reflect.isConstructorLike].
+@type {Constructor} Either creates a method or Defines a [can-define.types.typeConstructor Type] setting with a constructor function. Constructor functions are identified with [can-reflect.isConstructorLike].
 
-```js
-{
-	propertyName: Constructor
-}
-```
-OR
-```js
-{
-	propertyName: function() {}
-}
-```
+  ```js
+  {
+    propertyName: Constructor
+  }
+  ```
+  OR
+  ```js
+  {
+    propertyName: function() {}
+  }
+  ```
 
-For example:
-```js
-{
-	subMap: DefineMap // <- sets Type to DefineMap
-}
-```
-OR
-```js
-{
-	increment: function() {
-		++this.count;
-	} // <- sets method prop
-}
-```
+  For example:
+  ```js
+  {
+    subMap: DefineMap // <- sets Type to DefineMap
+  }
+  ```
+  OR
+  ```js
+  {
+    increment: function() {
+      ++this.count;
+    } // <- sets method prop
+  }
+  ```
 
-@type {Array} Defines an inline [can-define/list/list] Type setting. This is
-used as a shorthand for creating a property that is an [can-define/list/list] of another type.
+@type {Array} Defines an inline [can-define/list/list] Type setting. This is used as a shorthand for creating a property that is an [can-define/list/list] of another type.
 
-```js
-{
-	propertyName: [Constructor | propDefinitions]
-}
-```
+  ```js
+  {
+    propertyName: [Constructor | propDefinitions]
+  }
+  ```
 
-For example:
+  For example:
 
-```js
-{
-	users: [ User ],
-	todos: [ { complete: "boolean", name: "string" } ]
-}
-```
+  ```js
+  {
+    users: [ User ],
+    todos: [ { complete: "boolean", name: "string" } ]
+  }
+  ```
 
 @type {GETTER} Defines a property's [can-define.types.get] behavior with the
 [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get syntax].
 
-```js
-{
-	get propertyName() { /* ... */ }
-}
-```
+  ```js
+  {
+    get propertyName() { /* ... */ }
+  }
+  ```
 
-For example:
+  For example:
 
-```js
-{
-	get fullName() {
-		return this.first + " " + this.last;
-	}
-}
-```
+  ```js
+  import {DefineMap} from "can";
 
-This is a shorthand for providing an object with a `get` property like:
+  const Person = DefineMap.extend( {
+    first: "string",
+    last: "string",
+    get fullName() {
+      return this.first + " " + this.last;
+    }
+  } );
 
-```js
-{
-	fullName: {
-		get: function() {
-			return this.first + " " + this.last;
-		}
-	}
-}
-```
+  const person = new Person( {first: "Justin", last: "Meyer"} );
+  console.log( person.fullName ); //-> "Justin Meyer"
+  ```
+  @codepen
 
-You must use an object with a [can-define.types.get] property if you want your get to take the `lastSetValue` or `resolve` arguments.
+  This is a shorthand for providing an object with a `get` property like:
+
+  ```js
+  import {DefineMap} from "can";
+
+  const Person = DefineMap.extend( {
+    first: "string",
+    last: "string",
+    fullName {
+      get: function() {
+        return this.first + " " + this.last;
+      }
+    }
+  } );
+
+  const person = new Person( {first: "Justin", last: "Meyer"} );
+  console.log( person.fullName ); //-> "Justin Meyer"
+  ```
+  @codepen
+
+  You must use an object with a [can-define.types.get] property if you want your get to take the `lastSetValue` or `resolve` arguments.
 
 @type {SETTER} Defines a property's [can-define.types.set] behavior with the [set syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set).
 
-```js
-{
-	set propertyName( newValue ) { /* ... */ }
-}
-```
+  ```js
+  {
+    set propertyName( newValue ) { /* ... */ }
+  }
+  ```
 
-For example:
+  For example:
 
-```js
-{
-	set fullName( newValue ) {
-		const parts = newVal.split( " " );
-		this.first = parts[ 0 ];
-		this.last = parts[ 1 ];
-	}
-}
-```
+  ```js
+  import {DefineMap} from "can";
 
-This is a shorthand for providing an object with a `set` property like:
+  const Person = DefineMap.extend( {
+    fullName: {
+      set(newValue) {
+        const parts = newVal.split(" ");
+        this.first = parts[0];
+        this.last = parts[1];
+      }
+    }
+  } );
 
-```js
-{
-	fullName: {
-	    set: function(newValue){
-	        var parts = newVal.split(" ");
-	        this.first = parts[0];
-	        this.last = parts[1];
-	    }
-	}
-}
-```
+  const person = new Person( {fullName: "Justin Meyer"} );
+  console.log( person.first ); //-> "Justin"
+  console.log( person.last ); //-> "Meyer"
+  ```
+  @codepen
 
-You must use an object with a [can-define.types.set] property if you want your set to take the `resolve` argument.
+  This is a shorthand for providing an object with a `set` property like:
 
+  ```js
+  import {DefineMap} from "can";
+
+  const Person = DefineMap.extend( {
+    fullName: {
+      set: function(newValue) {
+        const parts = newVal.split(" ");
+        this.first = parts[0];
+        this.last = parts[1];
+      }
+    }
+  } );
+
+  const person = new Person( {fullName: "Justin Meyer"} );
+  console.log( person.first ); //-> "Justin"
+  console.log( person.last ); //-> "Meyer"
+  ```
+  @codepen
+
+  You must use an object with a [can-define.types.set] property if you want your set to take the `resolve` argument.
 
 @body
-
 
 ## Use
 
@@ -359,7 +416,7 @@ For example:
 
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 const Address = DefineMap.extend( "Address", {
     street: "string",
     state: "string"

--- a/docs/types.propDefinition.md
+++ b/docs/types.propDefinition.md
@@ -298,7 +298,7 @@ observable property.  These behaviors can be specified with as an `Object`, `Str
   } );
 
   const e = new Example();
-  console.log( e.propertyName );
+  console.log( e.propertyName ); //-> true
   ```
   @codepen
 

--- a/docs/types.propDefinition.md
+++ b/docs/types.propDefinition.md
@@ -135,25 +135,29 @@ observable property.  These behaviors can be specified with as an `Object`, `Str
   ```js
   import {DefineMap} from "can";
 
-  const book = DefineMap.extend( {
+  const Book = DefineMap.extend( {
     page: "number",
-    pageChangeCount: function( prop ) {
-      let count = 0;
+    pageChangeCount: {
+      value( prop ) {
+        let count = 0;
 
-      // When page changes, update the count.
-      prop.listenTo( "page", function() {
-        prop.resolve( ++count );
-      } );
+        // When page changes, update the count.
+        prop.listenTo( "page", function() {
+          prop.resolve( ++count );
+        } );
 
-      // Set initial count.
-      prop.resolve( count );
+        // Set initial count.
+        prop.resolve( count );
+      }
     }
   } );
+  const book = new Book();
+  book.on("pageChangeCount", () => {});
   book.page = 1;
   book.page += 1;
-  console.log( book.count ); //-> 2
+  console.log( book.pageChangeCount ); //-> 2
   ```
-  <!-- @codepen -->
+  @codepen
 
   A `value` definition makes the property __computed__ which means it will not be enumerable by default.
 
@@ -306,7 +310,7 @@ observable property.  These behaviors can be specified with as an `Object`, `Str
   const Person = DefineMap.extend( {
     first: "string",
     last: "string",
-    fullName {
+    fullName: {
       get: function() {
         return this.first + " " + this.last;
       }

--- a/docs/types.propDefinition.md
+++ b/docs/types.propDefinition.md
@@ -291,10 +291,16 @@ observable property.  These behaviors can be specified with as an `Object`, `Str
 [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get syntax].
 
   ```js
-  {
-    get propertyName() { /* ... */ }
-  }
+  import {DefineMap} from "can";
+
+  const Example = DefineMap.extend( {
+    get propertyName() { return true; }
+  } );
+
+  const e = new Example();
+  console.log( e.propertyName );
   ```
+  @codepen
 
   For example:
 

--- a/docs/types.set.md
+++ b/docs/types.set.md
@@ -65,7 +65,7 @@ The following makes setting a `page` property update the `offset`:
 
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 
 const Pages = DefineMap.extend( {
     limit: { default: 5 },
@@ -78,14 +78,14 @@ const Pages = DefineMap.extend( {
 } );
 const book = new Pages();
 book.page = 10;
-console.log(book.offset); //-> 45
+console.log( book.offset ); //-> 45
 ```
 @codepen
 
 The following makes changing `makeId` un-define the `modelId` property:
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 
 const Car = DefineMap.extend( {
 	modelId: { default: undefined },
@@ -102,9 +102,9 @@ const Car = DefineMap.extend( {
 } );
 
 const myCar = new Car({ makeId: "GMC", modelId: "Jimmy" });
-console.log(myCar.modelId) ;//-> "Jimmy"
+console.log( myCar.modelId ); //-> "Jimmy"
 myCar.makeId = "Chevrolet";
-console.log(myCar.modelId); //-> undefined
+console.log( myCar.modelId ); //-> undefined
 ```
 @codepen
 
@@ -130,7 +130,7 @@ When a setter returns `undefined`, its behavior changes depending on the number 
 With 0 arguments, the original set value is set on the attribute.
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 
 const MyMap = DefineMap.extend( {
 	prop: { set: function() {} }
@@ -138,14 +138,14 @@ const MyMap = DefineMap.extend( {
 
 const map = new MyMap( { prop: "foo" } );
 
-console.log(map.prop); //-> "foo"
+console.log( map.prop ); //-> "foo"
 ```
 @codepen
 
 With 1 argument, an `undefined` return value will set the property to `undefined`.  
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 
 const MyMap = DefineMap.extend( {
 	prop: { set: function( newVal ) {} }
@@ -153,7 +153,7 @@ const MyMap = DefineMap.extend( {
 
 const map = new MyMap( { prop: "foo" } );
 
-console.log(map.prop); //-> undefined
+console.log( map.prop ); //-> undefined
 ```
 @codepen
 
@@ -161,7 +161,7 @@ With 2 arguments, `undefined` leaves the property in place.  It is expected
 that `resolve` will be called:
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 
 const MyMap = DefineMap.extend( {
 	prop: {
@@ -173,7 +173,7 @@ const MyMap = DefineMap.extend( {
 
 const map = new MyMap( { prop: "foo" } );
 
-console.log(map.prop); //-> "food";
+console.log( map.prop ); //-> "food";
 ```
 @codepen
 
@@ -202,8 +202,8 @@ const Paginate = DefineMap.extend( {
 const p = new Paginate( { limit: 10, offset: 20 } );
 p.set({ page: 13 });
 
-console.log(p.offset); //-> 120
-console.log(p.page); //-> 13
+console.log( p.offset ); //-> 120
+console.log( p.page ); //-> 13
 ```
 @codepen
 
@@ -213,7 +213,7 @@ console.log(p.page); //-> 13
 By default, if a value returned from a setter is an object the effect will be to replace the property with the new object completely.
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 
 const Contact = DefineMap.extend( {
 	info: {
@@ -231,14 +231,14 @@ const info = alice.info;
 
 alice.info = { name: "Allison Wonderland", phone: "888-888-8888" };
 
-console.log(info === alice.info); // -> false
+console.log( info === alice.info ); // -> false
 ```
 @codepen
 
 In contrast, you can merge properties with:
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 
 const Contact = DefineMap.extend( {
 	info: {
@@ -260,7 +260,7 @@ const info = alice.info;
 
 alice.info = { name: "Allison Wonderland", phone: "888-888-8888" };
 
-console.log(info === alice.info); // -> true
+console.log( info === alice.info ); // -> true
 ```
 @codepen
 

--- a/docs/types.set.md
+++ b/docs/types.set.md
@@ -184,7 +184,7 @@ A set function provides a useful hook for performing side effect logic as a cert
 In the example below, Paginator DefineMap includes a `page` property, which derives its value entirely from other properties (limit and offset).  If something tries to set the `page` directly, the set method will set the value of `offset`:
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 
 const Paginate = DefineMap.extend( {
 	limit: "number",

--- a/docs/types.set.md
+++ b/docs/types.set.md
@@ -200,10 +200,9 @@ const Paginate = DefineMap.extend( {
 } );
 
 const p = new Paginate( { limit: 10, offset: 20 } );
-p.set({ page: 13 });
 
-console.log( p.offset ); //-> 120
-console.log( p.page ); //-> 13
+console.log( p.offset ); //-> 20
+console.log( p.page ); //-> 2
 ```
 @codepen
 

--- a/docs/value.md
+++ b/docs/value.md
@@ -176,7 +176,7 @@ Our next example shows how [can-define.types.get] should be used with the
 that derives its value from the instantaneous `first` and `last` values:
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 
 const Person = DefineMap.extend( "Person", {
 	first: "string",
@@ -187,7 +187,7 @@ const Person = DefineMap.extend( "Person", {
 } );
 
 const p = new Person({ first: "John", last: "Smith" });
-console.log(p.fullName); //-> "John Smith"
+console.log( p.fullName ); //-> "John Smith"
 ```
 @codepen
 
@@ -198,7 +198,7 @@ passage of time.
 The following `fullNameChangeCount` increments every time `fullName` changes:
 
 ```js
-import { DefineMap } from "can";
+import {DefineMap} from "can";
 
 const Person = DefineMap.extend( "Person", {
 	first: "string",

--- a/docs/value.md
+++ b/docs/value.md
@@ -5,65 +5,64 @@ Specify the behavior of a property by listening to changes in other properties.
 
 @signature `value(prop)`
 
-The `value` behavior is used to compose a property value from events dispatched
-by other properties on the map. It's similar to [can-define.types.get], but can
-be used to build property behaviors that [can-define.types.get] can not provide.
+  The `value` behavior is used to compose a property value from events dispatched
+  by other properties on the map. It's similar to [can-define.types.get], but can
+  be used to build property behaviors that [can-define.types.get] can not provide.
 
-`value` enables techniques very similar to using event streams and functional
-reactive programming. Use `prop.listenTo` to listen to events dispatched on
-the map or other observables, `prop.stopListening` to stop listening to those
-events if needed, and `prop.resolve` to set a new value on the observable.
-For example, the following counts the number of times the `name` property changed:
+  `value` enables techniques very similar to using event streams and functional
+  reactive programming. Use `prop.listenTo` to listen to events dispatched on
+  the map or other observables, `prop.stopListening` to stop listening to those
+  events if needed, and `prop.resolve` to set a new value on the observable.
+  For example, the following counts the number of times the `name` property changed:
 
   ```js
-  import { DefineMap } from "can";
+  import {DefineMap} from "can";
 
   const Person = DefineMap.extend( "Person", {
     name: "string",
     nameChangeCount: {
       value( prop ) {
         let count = 0;
-
+        
         prop.listenTo( "name", () => {
           prop.resolve( ++count );
         } );
-
         prop.resolve( count );
       }
     }
   } );
 
   const p = new Person();
-  p.on( "nameChangedCount", ( ev, newVal ) => {
-    console.log( "name changed", newVal, "times" );
+  p.on( "nameChangeCount", ( ev, newValue ) => {
+    console.log( "name changed " + newValue + " times." );
   } );
 
   p.name = "Justin"; // logs name changed 1 times
   p.name = "Ramiya"; // logs name changed 2 times
   ```
-  <!-- @codepen -->
+  @codepen
 
-If the property defined by `value` is unbound, the `value` function will be called each time. Use `prop.resolve` synchronously
-to provide a value.
+  If the property defined by `value` is unbound, the `value` function will be called each time. Use `prop.resolve` synchronously
+  to provide a value.
 
-[can-define.types.type], [can-define.types.default], [can-define.types.get], and [can-define.types.set] behaviors are ignored when `value` is present.
+  [can-define.types.type], [can-define.types.default], [can-define.types.get], and [can-define.types.set] behaviors are ignored when `value` is present.
 
-`value` properties are not enumerable by default.
+  `value` properties are not enumerable by default.
 
-@param {can-define.types.valueOptions} [prop] An object of methods and values used to specify the property
-behavior:  
+  @param {can-define.types.valueOptions} [prop] An object of methods and values used to specify the property
+  behavior:  
 
 
 
-- __prop.resolve(value)__ `{function(Any)}` Sets the value of this property as `value`. During a [can-queues.batch.start batch],
-  the last value passed to `prop.resolve` will be used as the value.
+  - __prop.resolve(value)__ `{function(Any)}` Sets the value of this property as `value`. During a [can-queues.batch.start batch],
+    the last value passed to `prop.resolve` will be used as the value.
 
-- __prop.listenTo(bindTarget, event, handler, queue)__ `{function(Any,String,Fuction,String)}`  A function that sets up a binding that
-  will be automatically torn-down when the `value` property is unbound.  This `prop.listenTo` method is very similar to the [can-event-queue/map/map.listenTo] method available on [can-define/map/map DefineMap].  It differs only that it:
+  - __prop.listenTo(bindTarget, event, handler, queue)__ `{function(Any,String,Fuction,String)}`  A function that sets up a binding that
+    will be automatically torn-down when the `value` property is unbound.  This `prop.listenTo` method is very similar to the [can-event-queue/map/map.listenTo] method available on [can-define/map/map DefineMap].  It differs only that it:
 
-  - defaults bindings within the [can-queues.notifyQueue].
-  - calls handlers with `this` as the instance.
-  - localizes saved bindings to the property instead of the entire map.
+    - defaults bindings within the [can-queues.notifyQueue].
+    - calls handlers with `this` as the instance.
+    - localizes saved bindings to the property instead of the entire map.
 
   Examples:
 
@@ -81,11 +80,11 @@ behavior:
   prop.listenTo( observable, handler );
   ```
 
-- __prop.stopListening(bindTarget, event, handler, queue)__ `{function(Any,String,Fuction,String)}`  A function that removes bindings
-  registered by the `prop.listenTo` argument.  This `prop.stopListening` method is very similar to the [can-event-queue/map/map.stopListening] method available on [can-define/map/map DefineMap].  It differs only that it:
+  - __prop.stopListening(bindTarget, event, handler, queue)__ `{function(Any,String,Fuction,String)}`  A function that removes bindings
+    registered by the `prop.listenTo` argument.  This `prop.stopListening` method is very similar to the [can-event-queue/map/map.stopListening] method available on [can-define/map/map DefineMap].  It differs only that it:
 
-  - defaults to unbinding within the [can-queues.notifyQueue].
-  - unbinds saved bindings by `prop.listenTo`.
+    - defaults to unbinding within the [can-queues.notifyQueue].
+    - unbinds saved bindings by `prop.listenTo`.
 
   Examples:
 
@@ -111,10 +110,10 @@ behavior:
   prop.stopListening( observable );
   ```
 
-- __prop.lastSet__ `{can-simple-observable}` An observable value that gets set when this
-  property is set.  You can read its value or listen to when its value changes to
-  derive the property value.  The following makes `property` behave like a
-  normal object property that can be get or set:
+  - __prop.lastSet__ `{can-simple-observable}` An observable value that gets set when this
+    property is set.  You can read its value or listen to when its value changes to
+    derive the property value.  The following makes `property` behave like a
+    normal object property that can be get or set:
 
   ```js
   {
@@ -131,37 +130,38 @@ behavior:
   }
   ```
 
-
 @return {function} An optional teardown function. If provided, the teardown function
-will be called when the property is unbound after `stopListening()` is used to
-remove all bindings.
+  will be called when the property is unbound after `stopListening()` is used to
+  remove all bindings.
 
-The following `time` property increments every second.  Notice how a function
-is returned to clear the interval when the property is returned:
+  The following `time` property increments every second.  Notice how a function
+  is returned to clear the interval when the property is returned:
 
   ```js
-const Timer = DefineMap.extend( "Timer", {
-	time: {
-		value( prop ) {
-			prop.resolve( new Date() );
+  import {DefineMap} from "can";
 
-			const interval = setInterval( () => {
-				prop.resolve( new Date() );
-			}, 1000 );
+  const Timer = DefineMap.extend( "Timer", {
+    time: {
+      value( prop ) {
+        prop.resolve( new Date() );
 
-			return () => {
-				clearInterval( interval );
-			};
-		}
-	}
-} );
+        const interval = setInterval( () => {
+          prop.resolve( new Date() );
+        }, 1000 );
 
-const timer = new Timer();
-timer.on( "time", function( ev, newVal, oldVal ) {
-	console.log( newVal ); //-> logs a new date every second
-} );
+        return () => {
+          clearInterval( interval );
+        };
+      }
+    }
+  } );
+
+  const timer = new Timer();
+  timer.on( "time", function( ev, newVal, oldVal ) {
+    console.log( newVal ); //-> logs a new date every second
+  } );
   ```
-  <!-- @codepen -->
+  @codepen
 
 @body
 

--- a/docs/value.md
+++ b/docs/value.md
@@ -64,21 +64,21 @@ Specify the behavior of a property by listening to changes in other properties.
     - calls handlers with `this` as the instance.
     - localizes saved bindings to the property instead of the entire map.
 
-  Examples:
+    Examples:
 
-  ```js
-  // Binds to the map's `name` event:
-  prop.listenTo( "name", handler );
+    ```js
+    // Binds to the map's `name` event:
+    prop.listenTo( "name", handler );
 
-  // Binds to the todos `length` event:
-  prop.listenTo( todos, "length", handler );
+    // Binds to the todos `length` event:
+    prop.listenTo( todos, "length", handler );
 
-  // Binds to the `todos` `length` event in the mutate queue:
-  prop.listenTo( todos, "length", handler, "mutate" );
+    // Binds to the `todos` `length` event in the mutate queue:
+    prop.listenTo( todos, "length", handler, "mutate" );
 
-  // Binds to an `onValue` emitter:
-  prop.listenTo( observable, handler );
-  ```
+    // Binds to an `onValue` emitter:
+    prop.listenTo( observable, handler );
+    ```
 
   - __prop.stopListening(bindTarget, event, handler, queue)__ `{function(Any,String,Fuction,String)}`  A function that removes bindings
     registered by the `prop.listenTo` argument.  This `prop.stopListening` method is very similar to the [can-event-queue/map/map.stopListening] method available on [can-define/map/map DefineMap].  It differs only that it:
@@ -86,49 +86,58 @@ Specify the behavior of a property by listening to changes in other properties.
     - defaults to unbinding within the [can-queues.notifyQueue].
     - unbinds saved bindings by `prop.listenTo`.
 
-  Examples:
+    Examples:
 
-  ```js
-  // Unbind all handlers bound using `listenTo`:
-  prop.stopListening();
+    ```js
+    // Unbind all handlers bound using `listenTo`:
+    prop.stopListening();
 
-  // Unbind handlers to the map's `name` event:
-  prop.stopListening( "name" );
+    // Unbind handlers to the map's `name` event:
+    prop.stopListening( "name" );
 
-  // Unbind a specific handler on the map's `name` event
-  // registered in the "notify" queue.
-  prop.stopListening( "name", handler );
+    // Unbind a specific handler on the map's `name` event
+    // registered in the "notify" queue.
+    prop.stopListening( "name", handler );
 
-  // Unbind all handlers bound to `todos` using `listenTo`:
-  prop.stopListening( todos );
+    // Unbind all handlers bound to `todos` using `listenTo`:
+    prop.stopListening( todos );
 
-  // Unbind all `length` handlers bound to `todos`
-  // using `listenTo`:
-  prop.stopListening( todos, "length" );
+    // Unbind all `length` handlers bound to `todos`
+    // using `listenTo`:
+    prop.stopListening( todos, "length" );
 
-  // Unbind all handlers to an `onValue` emitter:
-  prop.stopListening( observable );
-  ```
+    // Unbind all handlers to an `onValue` emitter:
+    prop.stopListening( observable );
+    ```
 
   - __prop.lastSet__ `{can-simple-observable}` An observable value that gets set when this
     property is set.  You can read its value or listen to when its value changes to
     derive the property value.  The following makes `property` behave like a
     normal object property that can be get or set:
 
-  ```js
-  {
-	property: {
-      value: function( prop ) {
+    ```js
+    import {DefineMap} from "can";
 
-        // Set `property` initial value to set value.
-        prop.resolve( prop.lastSet.get() );
+    const Example = DefineMap.extend( {
+      property: {
+        value: function( prop ) {
 
-        // When the property is set, update `property`.
-        prop.listenTo( prop.lastSet, prop.resolve );
+          console.log( prop.lastSet.get() ); //-> "test"
+    
+          // Set `property` initial value to set value.
+          prop.resolve( prop.lastSet.get() );
+
+          // When the property is set, update `property`.
+          prop.listenTo( prop.lastSet, prop.resolve );
+        }
       }
-    }
-  }
-  ```
+    } );
+
+    const e = new Example();
+    e.property = "test";
+    e.serialize();
+    ```
+    @codepen
 
 @return {function} An optional teardown function. If provided, the teardown function
   will be called when the property is unbound after `stopListening()` is used to
@@ -146,7 +155,11 @@ Specify the behavior of a property by listening to changes in other properties.
         prop.resolve( new Date() );
 
         const interval = setInterval( () => {
-          prop.resolve( new Date() );
+
+          const date = new Date()
+          console.log( date.getSeconds() ); //-> logs a new date every second
+          
+          prop.resolve( date );
         }, 1000 );
 
         return () => {
@@ -157,9 +170,11 @@ Specify the behavior of a property by listening to changes in other properties.
   } );
 
   const timer = new Timer();
-  timer.on( "time", function( ev, newVal, oldVal ) {
-    console.log( newVal.getSeconds() ); //-> logs a new date every second
-  } );
+  timer.listenTo( "time", () => {} );
+
+  setTimeout( () => {
+    timer.stopListening( "time" );
+  }, 5000 ); //-> stops logging after five seconds
   ```
   @codepen
 

--- a/docs/value.md
+++ b/docs/value.md
@@ -138,7 +138,7 @@ Specify the behavior of a property by listening to changes in other properties.
   is returned to clear the interval when the property is returned:
 
   ```js
-  import {DefineMap} from "can";
+  import {DefineMap} from "//unpkg.com/can@5/core.mjs";
 
   const Timer = DefineMap.extend( "Timer", {
     time: {
@@ -158,7 +158,7 @@ Specify the behavior of a property by listening to changes in other properties.
 
   const timer = new Timer();
   timer.on( "time", function( ev, newVal, oldVal ) {
-    console.log( newVal ); //-> logs a new date every second
+    console.log( newVal.getSeconds() ); //-> logs a new date every second
   } );
   ```
   @codepen

--- a/docs/value.md
+++ b/docs/value.md
@@ -138,7 +138,7 @@ Specify the behavior of a property by listening to changes in other properties.
   is returned to clear the interval when the property is returned:
 
   ```js
-  import {DefineMap} from "//unpkg.com/can@5/core.mjs";
+  import {DefineMap} from "can";
 
   const Timer = DefineMap.extend( "Timer", {
     time: {


### PR DESCRIPTION
This further fixes the following issues in #362.

## [can-define.types.serialize.html](https://canjs.com/doc/can-define.types.serialize.html)
- [x] [Boolean](https://canjs.com/doc/can-define.types.serialize.html#serialize_currentValue_propertyName_) should have an example to go along  with it
- [x] [Use](https://canjs.com/doc/can-define.types.serialize.html#Use) examples should be codepen-able and relevant  examples.
- [x] The first example in [Use](https://canjs.com/doc/can-define.types.serialize.html#Use) probably doesn't work since `map` returns a new array based on returned values in the callback. (If map works differently here there should be a link to that map).

## [can-define.types.type.html](https://canjs.com/doc/can-define.types.type.html)
- [x] Codepen-able run-able examples
- [x] compute is undefined under [Use](https://canjs.com/doc/can-define.types.type.html#Use) _Working with the 'compute' type_. After some research it seems compute may be depreciated [its documentation](https://canjs.com/doc/can-compute.html) is under legacy. `import { compute } from "//unpkg.com/can@5/legacy.js";` doesn't import stating `Uncaught TypeError: Failed to resolve module specifier "can-compute". Relative references must start with either "/", "./", or "../".` -- was fixed by __deleting__ the section!

## [can-define.types.value.html](https://canjs.com/doc/can-define.types.value.html)

- [x] [value( prop )](https://canjs.com/doc/can-define.types.value.html#value_prop_)'s first example should be codepen-able
- [x] The _Returns_ subheading under [value( prop )](https://canjs.com/doc/can-define.types.value.html#value_prop_) example should be codepen-able and loggable.
- [x] Both examples under [Use](https://canjs.com/doc/can-define.types.value.html#Use) should be codepen-able and loggable.