### PR TITLE
Make serialized DefineMaps observable with late-defined properties

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -395,6 +395,11 @@ define.makeDefineInstanceKey = function(constructor) {
 		} else {
 			defineResult.methods[property] = definition;
 		}
+
+		this.prototype.dispatch({
+			type: "can.keys",
+			target: this.prototype
+		});
 	};
 };
 

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1456,3 +1456,27 @@ QUnit.test("do not enumerate anything other than key properties (#369)", functio
 		aMethod: true // TODO: this should be removed someday
 	});
 });
+
+QUnit.test("Properties added via defineInstanceKey are observable", function(){
+	var Type = DefineMap.extend({});
+	var map = new Type();
+
+	var obs = new Observation(function(){
+		return canReflect.serialize(map);
+	});
+
+	var count = 0;
+	canReflect.onValue(obs, function(val) {
+		count++;
+
+		if(count === 2) {
+			QUnit.deepEqual(val, {foo:"bar"}, "changed value");
+		}
+	});
+
+	canReflect.defineInstanceKey(Type, "foo", {
+		type: "string"
+	});
+
+	map.foo = "bar";
+});

--- a/map/map.js
+++ b/map/map.js
@@ -215,6 +215,7 @@ var defineMapProto = {
 	},
 	"can.getOwnEnumerableKeys": function(){
 		ObservationRecorder.add(this, 'can.keys');
+		ObservationRecorder.add(Object.getPrototypeOf(this), 'can.keys');
 		return keysForDefinition(this._define.definitions).concat(keysForDefinition(this._instanceDefinitions) );
 	},
 	"can.hasOwnKey": function(key) {


### PR DESCRIPTION
This makes it possible to define properties after an Observation has
already been created for a serialized DefineMap. See the test for an
example.

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
