### PR TITLE
Fixes enumerability in Safari

### DIFF
--- a/map/map.js
+++ b/map/map.js
@@ -289,7 +289,7 @@ eventsProtoSymbols.forEach(function(sym) {
 if(process.env.NODE_ENV !== 'production') {
 	// call `map.log()` to log all event changes
 	// pass `key` to only log the matching property, e.g: `map.log("foo")`
-	DefineMap.prototype.log = defineHelpers.log;
+	define.defineConfigurableAndNotEnumerable(DefineMap.prototype, "log", defineHelpers.log);
 }
 //!steal-remove-end
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/canjs/can-define",
   "dependencies": {
     "can-assign": "^1.1.1",
-    "can-construct": "^3.2.0",
+    "can-construct": "^3.5.2",
     "can-data-types": "<2.0.0",
     "can-define-lazy-value": "^1.0.0",
     "can-diff": "^1.0.0",


### PR DESCRIPTION
Safari, unlike Chrome, will count shadowed properties in a for/in loop.
Making them non-enumerable as well fixes it. Closes #389