### PR TITLE
Prevents _computed from being defined on DefineMap prototypes

### DIFF
--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1480,3 +1480,26 @@ QUnit.test("Properties added via defineInstanceKey are observable", function(){
 
 	map.foo = "bar";
 });
+
+QUnit.test("Serialized computes do not prevent getters from working", function(){
+	var Type = DefineMap.extend("MyType", {
+		page: "string",
+		myPage: {
+			get: function(last, resolve) {
+				return this.page;
+			}
+		}
+	});
+
+	var first = new Type({ page: "one" });
+	var firstObservation = new Observation(function() {
+		return canReflect.serialize(first);
+	});
+
+	var boundTo = Function.prototype;
+	canReflect.onValue(firstObservation, boundTo);
+
+	var second = new Type({ page: "two" });
+
+	QUnit.equal(second.myPage, "two", "Runs the getter correctly");
+});

--- a/map/map.js
+++ b/map/map.js
@@ -93,6 +93,18 @@ var DefineMap = Construct.extend("DefineMap",{
 					this.constructor.seal
 				);
 			});
+
+			var _computedGetter = Object.getOwnPropertyDescriptor(prototype, "_computed").get;
+			Object.defineProperty(prototype, "_computed", {
+				configurable: true,
+				enumerable: false,
+				get: function(){
+					if(this === prototype) {
+						return;
+					}
+					return _computedGetter.call(this, arguments);
+				}
+			});
 		} else {
 			for(key in prototype) {
 				define.defineConfigurableAndNotEnumerable(prototype, key, prototype[key]);


### PR DESCRIPTION
For DefineMaps, this prevents there from being a `_computed` property
that overrides the getter behavior (that sets the _computed on each
		instance). This is needed because of #388 which made DefineMap
prototypes observable themselves.

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
