### PR TITLE
Make sure to call an overwritten `setup` on the prototype.

### DIFF
--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1546,7 +1546,7 @@ QUnit.test("setup should be called (#395)", function(){
 		}
 	});
 
-	var Super = Base.extend("Super",{})
+	var Super = Base.extend("Super",{});
 
 	var base = new Base();
 	var supa = new Super();

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1536,3 +1536,20 @@ QUnit.test("Serialized computes do not prevent getters from working", function()
 
 	QUnit.equal(second.myPage, "two", "Runs the getter correctly");
 });
+
+QUnit.test("setup should be called (#395)", function(){
+	var calls = [];
+	var Base = DefineMap.extend("Base",{
+		setup: function(attrs) {
+			calls.push(this);
+			return DefineMap.prototype.setup.apply(this, arguments);
+		}
+	});
+
+	var Super = Base.extend("Super",{})
+
+	var base = new Base();
+	var supa = new Super();
+
+	QUnit.deepEqual(calls,[base, supa], "setup called");
+});

--- a/map/map.js
+++ b/map/map.js
@@ -73,6 +73,15 @@ function getSchema() {
 	return define.updateSchemaKeys(schema, definitions);
 }
 
+var sealedSetup = function(props){
+	define.setup.call(
+		this,
+		props || {},
+		this.constructor.seal
+	);
+};
+
+
 var DefineMap = Construct.extend("DefineMap",{
 	setup: function(base){
 		var key,
@@ -86,13 +95,10 @@ var DefineMap = Construct.extend("DefineMap",{
 			for(key in DefineMap.prototype) {
 				define.defineConfigurableAndNotEnumerable(prototype, key, prototype[key]);
 			}
-			define.defineConfigurableAndNotEnumerable(prototype, "setup", function(props){
-				define.setup.call(
-					this,
-					props || {},
-					this.constructor.seal
-				);
-			});
+			// If someone provided their own setup, we call that.
+			if(prototype.setup === DefineMap.prototype.setup) {
+				define.defineConfigurableAndNotEnumerable(prototype, "setup", sealedSetup);
+			}
 
 			var _computedGetter = Object.getOwnPropertyDescriptor(prototype, "_computed").get;
 			Object.defineProperty(prototype, "_computed", {


### PR DESCRIPTION
Partially fixes #395 ... if a user calls `DefineMap.prototype.setup` w/i their overwritten setup, it will not seal the map.  However, this can be done by calling `DefineMap.prototype.setup.call(this, props, true)`.