### PR TITLE
Fixes #397. Passes default value to Resolver

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -447,9 +447,11 @@ make = {
 		return computeObj;
 	},
 	valueResolver: function(prop, definition, typeConvert) {
+		var getDefault = make.get.defaultValue(prop, definition, typeConvert);
 		return function(){
 			var map = this;
-			var computeObj = make.computeObj(map, prop, new ResolverObservable(definition.value, map));
+			var defaultValue = getDefault.call(this);
+			var computeObj = make.computeObj(map, prop, new ResolverObservable(definition.value, map, defaultValue));
 			//!steal-remove-start
 			if(process.env.NODE_ENV !== 'production') {
 				Object.defineProperty(computeObj.handler, "name", {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "can-observation-recorder": "^1.0.0",
     "can-queues": "^1.0.0",
     "can-reflect": "^1.15.0",
-    "can-simple-observable": "^2.0.5",
+    "can-simple-observable": "^2.4.0",
     "can-single-reference": "^1.0.0",
     "can-string-to-any": "^1.0.1",
     "can-symbol": "^1.0.0"

--- a/test/test-define-only.js
+++ b/test/test-define-only.js
@@ -1284,3 +1284,21 @@ QUnit.test("canReflect.onKeyValue (#363)", function(){
 
 	greeting.message = "bye";
 });
+
+QUnit.test("value lastSet has default value (#397)", function() {
+	var Defaulted = function(defaultValue) {
+		this.hasDefault = defaultValue;
+	};
+
+	define(Defaulted.prototype, {
+		hasDefault: {
+			default: 42,
+			value: function hasDefaultValue(props) {
+				props.resolve(props.lastSet.get());
+			}
+		}
+	});
+	var defaulted = new Defaulted();
+	QUnit.equal(defaulted.hasDefault, 42,
+		"hasDefault value.lastSet set default value");
+});

--- a/test/test-define-only.js
+++ b/test/test-define-only.js
@@ -1286,14 +1286,13 @@ QUnit.test("canReflect.onKeyValue (#363)", function(){
 });
 
 QUnit.test("value lastSet has default value (#397)", function() {
-	var Defaulted = function(defaultValue) {
-		this.hasDefault = defaultValue;
-	};
+	var Defaulted = function() {};
 
 	define(Defaulted.prototype, {
 		hasDefault: {
 			default: 42,
 			value: function hasDefaultValue(props) {
+				QUnit.equal(props.lastSet.get(), 42, "props.lastSet works");
 				props.resolve(props.lastSet.get());
 			}
 		}


### PR DESCRIPTION
Addresses https://github.com/canjs/can-define/issues/397. 

Requires the merging of https://github.com/canjs/can-simple-observable/pull/36 before this will pass.
