### PR TITLE
ignore DefineList.includes tests for IE11

### DIFF
--- a/list/list-test.js
+++ b/list/list-test.js
@@ -1488,51 +1488,68 @@ QUnit.test("Bound serialized lists update when they change length", function(){
 });
 
 QUnit.test("'includes' method basics (#277)", function(assert) {
-	QUnit.expect(6);
-
-	var emptyList = new DefineList([]);
-	assert.notOk(emptyList.includes(2));
-
-	var list = new DefineList([1, 2, 3]);
-	assert.ok(list.includes(2));
-	assert.notOk(list.includes(4));
-	assert.notOk(list.includes(3, 3));
-	assert.ok(list.includes(3, -1));
-
-	var nanList = new DefineList([1, 2, NaN]);
-	assert.ok(nanList.includes(NaN));
+	if (typeof Array.prototype.includes === "function") {
+		QUnit.expect(6);
+	
+		var emptyList = new DefineList([]);
+		assert.notOk(emptyList.includes(2));
+	
+		var list = new DefineList([1, 2, 3]);
+		assert.ok(list.includes(2));
+		assert.notOk(list.includes(4));
+		assert.notOk(list.includes(3, 3));
+		assert.ok(list.includes(3, -1));
+	
+		var nanList = new DefineList([1, 2, NaN]);
+		assert.ok(nanList.includes(NaN));
+	} else {
+		expect(0);
+	}
 });
 
 QUnit.test("'fromIndex' is not >= to the array length", function(assert) {
-	QUnit.expect(2);
+	if (typeof Array.prototype.includes === "function") {
+		QUnit.expect(2);
 
-	var list = new DefineList(["a", "b", "c"]);
-	assert.notOk(list.includes("c", 3));
-	assert.notOk(list.includes("c", 100));
+		var list = new DefineList(["a", "b", "c"]);
+		assert.notOk(list.includes("c", 3));
+		assert.notOk(list.includes("c", 100));
+	} else {
+		expect(0);
+	}
 });
 
 QUnit.test("computed index is less than 0", function(assert) {
-	QUnit.expect(4);
+	if (typeof Array.prototype.includes === "function") {
+		QUnit.expect(4);
 
-	var list = new DefineList(["a", "b", "c"]);
-	assert.ok(list.includes("a", -100));
-	assert.ok(list.includes("b", -100));
-	assert.ok(list.includes("c", -100));
-	assert.notOk(list.includes("a", -2));
+		var list = new DefineList(["a", "b", "c"]);
+		assert.ok(list.includes("a", -100));
+		assert.ok(list.includes("b", -100));
+		assert.ok(list.includes("c", -100));
+		assert.notOk(list.includes("a", -2));
+	} else {
+		expect(0);
+	}
 });
 
 QUnit.test("Bound 'includes' (#277)", function(){
-	expect(1);
-	var list = new DefineList();
-	var obs = new Observation(function(){
-		return list.includes("foo");
-	});
+	if (typeof Array.prototype.includes === "function") {
+		expect(1);
+		var list = new DefineList();
+		var obs = new Observation(function(){
+			return list.includes("foo");
+		});
 
-	function onChange(val) {
-		ok(val);
+		// put it in an expression to avoid jshint "Function declarations should not be placed in blocks"
+		var onChange = function onChange(val) {
+			ok(val);
+		};
+
+		canReflect.onValue(obs, onChange);
+		list.push("foo");
+		canReflect.offValue(obs, onChange);
+	} else {
+		expect(0);
 	}
-
-	canReflect.onValue(obs, onChange);
-	list.push("foo");
-	canReflect.offValue(obs, onChange);
 });

--- a/list/list-test.js
+++ b/list/list-test.js
@@ -1487,40 +1487,32 @@ QUnit.test("Bound serialized lists update when they change length", function(){
 	canReflect.offValue(obs, onChange);
 });
 
-QUnit.test("'includes' method basics (#277)", function(assert) {
-	if (typeof Array.prototype.includes === "function") {
+if (typeof Array.prototype.includes === "function") {
+	QUnit.test("'includes' method basics (#277)", function(assert) {
 		QUnit.expect(6);
-	
+
 		var emptyList = new DefineList([]);
 		assert.notOk(emptyList.includes(2));
-	
+
 		var list = new DefineList([1, 2, 3]);
 		assert.ok(list.includes(2));
 		assert.notOk(list.includes(4));
 		assert.notOk(list.includes(3, 3));
 		assert.ok(list.includes(3, -1));
-	
+
 		var nanList = new DefineList([1, 2, NaN]);
 		assert.ok(nanList.includes(NaN));
-	} else {
-		expect(0);
-	}
-});
+	});
 
-QUnit.test("'fromIndex' is not >= to the array length", function(assert) {
-	if (typeof Array.prototype.includes === "function") {
+	QUnit.test("'fromIndex' is not >= to the array length", function(assert) {
 		QUnit.expect(2);
 
 		var list = new DefineList(["a", "b", "c"]);
 		assert.notOk(list.includes("c", 3));
 		assert.notOk(list.includes("c", 100));
-	} else {
-		expect(0);
-	}
-});
+	});
 
-QUnit.test("computed index is less than 0", function(assert) {
-	if (typeof Array.prototype.includes === "function") {
+	QUnit.test("computed index is less than 0", function(assert) {
 		QUnit.expect(4);
 
 		var list = new DefineList(["a", "b", "c"]);
@@ -1528,28 +1520,21 @@ QUnit.test("computed index is less than 0", function(assert) {
 		assert.ok(list.includes("b", -100));
 		assert.ok(list.includes("c", -100));
 		assert.notOk(list.includes("a", -2));
-	} else {
-		expect(0);
-	}
-});
+	});
 
-QUnit.test("Bound 'includes' (#277)", function(){
-	if (typeof Array.prototype.includes === "function") {
+	QUnit.test("Bound 'includes' (#277)", function(){
 		expect(1);
 		var list = new DefineList();
 		var obs = new Observation(function(){
 			return list.includes("foo");
 		});
 
-		// put it in an expression to avoid jshint "Function declarations should not be placed in blocks"
-		var onChange = function onChange(val) {
+		function onChange(val) {
 			ok(val);
-		};
+		}
 
 		canReflect.onValue(obs, onChange);
 		list.push("foo");
 		canReflect.offValue(obs, onChange);
-	} else {
-		expect(0);
-	}
-});
+	});
+}


### PR DESCRIPTION
For #419 

### The expected behavior:
```DefineList.includes``` tests should be ignored in not supported environment (IE11).

### The changes:
In every ```includes``` tests I checked if the ```Array.prototype.includes```  function is present to run the tests otherwise I added ```expect(0)``` (QUnit expects no tests).

 
