### PR TITLE
Using the Symbol instead of the __inSetup property

### DIFF
--- a/list/list-test.js
+++ b/list/list-test.js
@@ -1538,3 +1538,9 @@ if (typeof Array.prototype.includes === "function") {
 		canReflect.offValue(obs, onChange);
 	});
 }
+
+QUnit.test("Set __inSetup prop #421", function() {
+	var list = new DefineList([]);
+	list.set("__inSetup", "nope");
+	QUnit.equal(list.__inSetup, "nope");
+});

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1595,3 +1595,9 @@ QUnit.test("Set new prop to undefined #408", function(){
 	obj.set("foo", "bar");
 	QUnit.deepEqual(calledPatches, PATCHES);
 });
+
+QUnit.test("Set __inSetup prop #421", function() {
+	var map = new DefineMap({});
+	map.set("__inSetup", "nope");
+	QUnit.equal(map.__inSetup, "nope");
+});

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/canjs/can-define",
   "dependencies": {
     "can-assign": "^1.1.1",
-    "can-construct": "^3.5.2",
+    "can-construct": "^3.5.4",
     "can-data-types": "<2.0.0",
     "can-define-lazy-value": "^1.0.0",
     "can-diff": "^1.0.0",


### PR DESCRIPTION
Closes https://github.com/canjs/can-define/issues/421.
Depends on https://github.com/canjs/can-define/issues/421 (maybe not?)