### PR TITLE
Wildcard constructor types should work

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -1081,6 +1081,8 @@ define.expando = function(map, prop, value) {
 		// possibly convert value to List or DefineMap
 		if(defaultDefinition.type) {
 			map._data[prop] = define.make.set.type(prop, defaultDefinition.type, returnFirstArg).call(map, value);
+		} else if (defaultDefinition.Type && canReflect.isConstructorLike(defaultDefinition.Type)) {
+			map._data[prop] = define.make.set.Type(prop, defaultDefinition.Type, returnFirstArg).call(map, value);
 		} else {
 			map._data[prop] = define.types.observable(value);
 		}

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1601,3 +1601,30 @@ QUnit.test("Set __inSetup prop #421", function() {
 	map.set("__inSetup", "nope");
 	QUnit.equal(map.__inSetup, "nope");
 });
+
+QUnit.test("'*' wildcard type definitions that use constructors works for expandos #425", function(){
+	var MyType = function MyType() {};
+	MyType.prototype = {};
+
+	var OtherType = DefineMap.extend({ seal : false }, {
+		"*" : MyType
+	});
+
+	var map = new OtherType();
+	map.set( "foo", {});
+	var foo = map.get( "foo" );
+	QUnit.ok(foo instanceof MyType);
+});
+
+QUnit.test("'*' wildcard type definitions that use DefineMap constructors works for expandos #425", function(){
+	var MyType = DefineMap.extend({});
+
+	var OtherType = DefineMap.extend({ seal : false }, {
+		"*" : MyType
+	});
+
+	var map = new OtherType();
+	map.set( "foo", {});
+	var foo = map.get( "foo" );
+	QUnit.ok(foo instanceof MyType);
+});


### PR DESCRIPTION
For  #425

### The Changes

Now `define.expando` convert the value to the custom type if the `defaultDefinition` has `Type` property that has a `Constructor` type in the `*` wildcard type definition.