### PR TITLE
adds newValue and oldValue on event objects

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -433,7 +433,8 @@ define.makeDefineInstanceKey = function(constructor) {
 		}
 
 		this.prototype.dispatch({
-			type: "can.keys",
+			action: "can.keys",
+			type: "can.keys", // TODO: Remove in 6.0
 			target: this.prototype
 		});
 	};
@@ -470,8 +471,12 @@ make = {
 				computeObj.oldValue = newVal;
 
 				map.dispatch({
-					type: prop,
-					target: map
+					action: "set",
+					key: "prop",
+					target: map,
+					newValue: newVal,
+					oldValue: oldValue,
+					type: prop, // TODO: Remove in 6.0
 				}, [newVal, oldValue]);
 			}
 		};
@@ -547,11 +552,15 @@ make = {
 					var dispatched;
 					setData.call(this, newVal);
 
-					dispatched = {
-						patches: [{type: "set", key: prop, value: newVal}],
-						type: prop,
-						target: this
-					};
+						dispatched = {
+							patches: [{type: "set", key: prop, value: newVal}],
+							target: this,
+							action: "set",
+							newValue: newVal,
+							oldValue: current,
+							key: prop,
+							type: prop // TODO: Remove in 6.0
+						};
 
 					//!steal-remove-start
 					if(process.env.NODE_ENV !== 'production') {
@@ -1141,13 +1150,18 @@ define.expando = function(map, prop, value) {
 		if(!map[inSetupSymbol]) {
 			queues.batch.start();
 			map.dispatch({
-				type: "can.keys",
-				target: map
+				action: "can.keys",
+				target: map,
+				type: "can.keys" // TODO: Remove in 6.0
 			});
 			if(Object.prototype.hasOwnProperty.call(map._data, prop)) {
 				map.dispatch({
-					type: prop,
+					action: "add",
 					target: map,
+					newValue:  map._data[prop],
+					oldValue: undefined,
+					key: prop,
+					type: prop, // TODO: Remove in 6.0
 					patches: [{type: "add", key: prop, value: map._data[prop]}],
 				},[map._data[prop], undefined]);
 			} else {

--- a/can-define.js
+++ b/can-define.js
@@ -474,7 +474,7 @@ make = {
 					action: "set",
 					key: "prop",
 					target: map,
-					newValue: newVal,
+					value: newVal,
 					oldValue: oldValue,
 					type: prop, // TODO: Remove in 6.0
 				}, [newVal, oldValue]);
@@ -556,7 +556,7 @@ make = {
 							patches: [{type: "set", key: prop, value: newVal}],
 							target: this,
 							action: "set",
-							newValue: newVal,
+							value: newVal,
 							oldValue: current,
 							key: prop,
 							type: prop // TODO: Remove in 6.0
@@ -1158,7 +1158,7 @@ define.expando = function(map, prop, value) {
 				map.dispatch({
 					action: "add",
 					target: map,
-					newValue:  map._data[prop],
+					value:  map._data[prop],
 					oldValue: undefined,
 					key: prop,
 					type: prop, // TODO: Remove in 6.0

--- a/define-helpers/define-helpers.js
+++ b/define-helpers/define-helpers.js
@@ -96,7 +96,7 @@ var defineHelpers = {
 				this.dispatch({
 					action: "delete",
 					key: prop,
-					newValue: undefined,
+					value: undefined,
 					oldValue: oldValue,
 					type: prop, // TODO: Remove in 6.0
 					target: this,

--- a/define-helpers/define-helpers.js
+++ b/define-helpers/define-helpers.js
@@ -85,7 +85,8 @@ var defineHelpers = {
 			delete instanceDefines[prop];
 			queues.batch.start();
 			this.dispatch({
-				type: "can.keys",
+				action: "can.keys",
+				type: "can.keys", // TODO: Remove in 6.0
 				target: this
 			});
 			var oldValue = this._data[prop];
@@ -93,7 +94,11 @@ var defineHelpers = {
 				delete this._data[prop];
 				//delete this[prop];
 				this.dispatch({
-					type: prop,
+					action: "delete",
+					key: prop,
+					newValue: undefined,
+					oldValue: oldValue,
+					type: prop, // TODO: Remove in 6.0
 					target: this,
 					patches: [{type: "delete", key: prop}],
 				},[undefined,oldValue]);

--- a/list/list.js
+++ b/list/list.js
@@ -130,6 +130,10 @@ var DefineList = Construct.extend("DefineList",
 					patches = [{type: "splice", insert: newVal, index: index, deleteCount: 0}];
 					dispatched = {
 						type: how,
+						action: "splice",
+						insert: newVal,
+						index: index,
+						deleteCount: 0,
 						patches: patches
 					};
 
@@ -148,7 +152,10 @@ var DefineList = Construct.extend("DefineList",
 					patches = [{type: "splice", index: index, deleteCount: oldVal.length}];
 					dispatched = {
 						type: how,
-						patches: patches
+						patches: patches,
+						action: "splice",
+						index: index, deleteCount: oldVal.length,
+						target: this
 					};
 					//!steal-remove-start
 					if(process.env.NODE_ENV !== 'production') {
@@ -161,6 +168,7 @@ var DefineList = Construct.extend("DefineList",
 					this.dispatch(how, [ newVal, index ]);
 				}
 			} else {
+				console.log("list dispatching", attr, newVal, oldVal);
 				this.dispatch({
 					type: "" + attr,
 					target: this

--- a/list/list.js
+++ b/list/list.js
@@ -168,7 +168,6 @@ var DefineList = Construct.extend("DefineList",
 					this.dispatch(how, [ newVal, index ]);
 				}
 			} else {
-				console.log("list dispatching", attr, newVal, oldVal);
 				this.dispatch({
 					type: "" + attr,
 					target: this

--- a/map/map-test.js
+++ b/map/map-test.js
@@ -1199,7 +1199,7 @@ canTestHelpers.devOnlyTest("can.hasKey and can.hasOwnKey (#303) (#412)", functio
 	assert.equal(vm[hasOwnKeySymbol]("parentDerivedProp"), false, "vm.hasOwnKey('parentDerivedProp') false");
 
 	assert.equal(vm[hasOwnKeySymbol]("anotherProp"), false, "vm.hasOwnKey('anotherProp') false");
-	
+
 	var map = new DefineMap({expandoKey: undefined});
 	assert.equal(map[hasKeySymbol]("expandoKey"), true, "map.hasKey('expandoKey')  (#412)");
 });
@@ -1632,4 +1632,8 @@ QUnit.test("'*' wildcard type definitions that use DefineMap constructors works 
 	map.set( "foo", {});
 	var foo = map.get( "foo" );
 	assert.ok(foo instanceof MyType);
+});
+
+require("can-reflect-tests/observables/map-like/instance/on-event-get-set-delete-key")("DefineMap", function(){
+    return new DefineMap();
 });

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "can-symbol": "^1.0.0"
   },
   "devDependencies": {
-    "can-reflect-tests": "<0.3.0",
+    "can-reflect-tests": "^1.0.0",
     "can-test-helpers": "^1.1.4",
     "detect-cyclic-packages": "^1.1.0",
     "jshint": "^2.9.1",


### PR DESCRIPTION
For https://github.com/canjs/canjs/issues/4656



Dispatches events with:

```
action: "set",
key: prop,
target: map,
newValue: newVal,
oldValue: oldValue,
```

This enables:

```
map.on("key", ({newValue}) => {})
```

type functions.