### PR TITLE
Improve documentation for propDefinitions

### DIFF
--- a/map/docs/static.extend.md
+++ b/map/docs/static.extend.md
@@ -43,7 +43,7 @@
   @param {Object} [static] Static properties that are set directly on the
   constructor function.
 
-  @param {Object<String,Function|can-define.types.propDefinition>} prototype A definition of the properties or methods on this type.
+  @param {can-define.types.propDefinition} prototype A definition of the properties or methods on this type. See [can-define.types.propDefinition] for all available property definitions.
 
 @body
 


### PR DESCRIPTION
Change the param to be of `propDefinitions` and include sentence with link to `propDefinitions`

<img width="1792" alt="Screenshot 2019-04-25 at 21 33 07" src="https://user-images.githubusercontent.com/4574152/56768833-51bc3900-67a7-11e9-8557-b457bb8af4a4.png">

Issue - https://github.com/canjs/can-define/issues/279