### PR TITLE
#461: Tests using canReflect.getName in assertions fail in IE11

### DIFF
--- a/test/test-define-only.js
+++ b/test/test-define-only.js
@@ -1384,8 +1384,9 @@ QUnit.test("binding computed properties do not observation recordings (#406)", f
 });
 
 testHelpers.dev.devOnlyTest("warning when setting during a get", function(assert){
-	var msg = "can-define: The prop2 property on Type{} is being set in Type{}'s prop getter. This can cause infinite loops and performance issues. Use the value() behavior for prop2 instead, and listen to other properties and observables with listenTo(). https://canjs.com/doc/can-define.types.value.html";
 	var Type = function Type() {};
+
+	var msg = /.* This can cause infinite loops and performance issues.*/;
 	var teardownWarn = testHelpers.dev.willWarn(msg, function(text, match) {
 		if(match) {
 			assert.ok(true, "warning fired");

--- a/test/test.html
+++ b/test/test.html
@@ -1,3 +1,3 @@
 <!DOCTYPE html>
 <title>can-define tests</title>
-<script src="../node_modules/steal/steal.js" main="can-define/test/test"></script>
+<script src="../node_modules/steal/steal-with-promises.js" main="can-define/test/test"></script>

--- a/test/test.html
+++ b/test/test.html
@@ -1,3 +1,3 @@
 <!DOCTYPE html>
 <title>can-define tests</title>
-<script src="../node_modules/steal/steal-with-promises.js" main="can-define/test/test"></script>
+<script src="../node_modules/steal/steal.js" main="can-define/test/test"></script>


### PR DESCRIPTION
Fixed using RegEx for [Issue #461](https://github.com/canjs/can-define/issues/461)