### PR TITLE
465 warn for getter with type and 466 default with falsey value

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -233,11 +233,19 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 
 	//!steal-remove-start
 	if(process.env.NODE_ENV !== 'production') {
-        if(definition.get && definition.get.length === 0 && ( definition.default || definition.Default ) ) {
-            canLogDev.warn("can-define: Default value for property " +
-                canReflect.getName(typePrototype)+"."+ prop +
-                " ignored, as its definition has a zero-argument getter");
-        }
+		if(definition.get && definition.get.length === 0 && ( definition.default || definition.Default ) ) {
+				canLogDev.warn("can-define: Default value for property " +
+						canReflect.getName(typePrototype)+"."+ prop +
+						" ignored, as its definition has a zero-argument getter");
+		}
+
+		if(definition.get && definition.get.length === 0 && ( definition.type || definition.Type ) ) {
+			var warning = definition.type ? 'type' : 'Type';
+			canLogDev.warn("can-define: " + warning + " value for property " +
+					canReflect.getName(typePrototype)+"."+ prop +
+					" ignored, as its definition has a zero-argument getter");
+		}
+
 		if (type && canReflect.isConstructorLike(type) && !isDefineType(type)) {
 			canLogDev.warn(
 				"can-define: the definition for " + canReflect.getName(typePrototype) + "."+

--- a/can-define.js
+++ b/can-define.js
@@ -233,7 +233,7 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 
 	//!steal-remove-start
 	if(process.env.NODE_ENV !== 'production') {
-		if(definition.get && definition.get.length === 0 && ( definition.default || definition.Default ) ) {
+		if(definition.get && definition.get.length === 0 && ( "default" in definition || "Default" in definition ) ) {
 				canLogDev.warn("can-define: Default value for property " +
 						canReflect.getName(typePrototype)+"."+ prop +
 						" ignored, as its definition has a zero-argument getter");

--- a/test/test-define-only.js
+++ b/test/test-define-only.js
@@ -1223,7 +1223,7 @@ testHelpers.dev.devOnlyTest("Setting a value with only a get() generates a warni
 	assert.equal(finishErrorCheck(), 1);
 });
 
-testHelpers.dev.devOnlyTest("Setter with getter that doesn't take `lastSet` throws an unhelpful error (#367)", function (assert) {
+testHelpers.dev.devOnlyTest("Setter with getter that doesn't take `lastSet` warns (#367)", function (assert) {
 	assert.expect(3);
 
 	var VM = function() {};
@@ -1251,7 +1251,7 @@ testHelpers.dev.devOnlyTest("Setter with getter that doesn't take `lastSet` thro
 
 });
 
-testHelpers.dev.devOnlyTest("Setter with Type or type that doesn't take `lastSet` should warn (#465)", function (assert) {
+testHelpers.dev.devOnlyTest("Getter with Type or type that doesn't take `lastSet` should warn (#465)", function (assert) {
 	assert.expect(6);
 
 	var VM = function() {};
@@ -1294,8 +1294,8 @@ testHelpers.dev.devOnlyTest("Setter with Type or type that doesn't take `lastSet
 
 });
 
-testHelpers.dev.devOnlyTest("Default with getter that doesn't take `lastSet` throws an unhelpful error (#367)", function (assert) {
-	assert.expect(3);
+testHelpers.dev.devOnlyTest("Default with getter that doesn't take `lastSet` warns (#367)", function (assert) {
+	assert.expect(6);
 
 	var VM = function() {};
 
@@ -1316,7 +1316,26 @@ testHelpers.dev.devOnlyTest("Default with getter that doesn't take `lastSet` thr
 			}
 		}
 	});
-	// debugger
+
+	assert.equal(finishErrorCheck(), 1, 'There was 1 warning');
+
+	message = "can-define: Default value for property "+canReflect.getName(VM.prototype)+".derivedProp ignored, as its definition has a zero-argument getter";
+	finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
+
+		assert.equal(actualMessage, message, "Warning is expected message");
+		assert.ok(success);
+	});
+
+
+	define(VM.prototype, {
+		derivedProp: {
+			default: '',
+			get: function() {
+				return "I Love Software";
+			}
+		}
+	});
+
 	assert.equal(finishErrorCheck(), 1, 'There was 1 warning');
 
 });

--- a/test/test-define-only.js
+++ b/test/test-define-only.js
@@ -1239,11 +1239,54 @@ testHelpers.dev.devOnlyTest("Setter with getter that doesn't take `lastSet` thro
 	define(VM.prototype, {
 		derivedProp: {
 			set: function(testVar) {
-    			return testVar;
-    		},
+				return testVar;
+			},
 			get: function() {
 				return "Bitovi Is Awesome";
 			}
+		}
+	});
+
+	assert.equal(finishErrorCheck(), 1);
+
+});
+
+testHelpers.dev.devOnlyTest("Setter with Type or type that doesn't take `lastSet` should warn (#465)", function (assert) {
+	assert.expect(6);
+
+	var VM = function() {};
+
+	var message = "can-define: Type value for property "+canReflect.getName(VM.prototype)+".derivedProp ignored, as its definition has a zero-argument getter";
+	var finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
+
+		assert.equal(actualMessage, message, "Warning is expected message");
+		assert.ok(success);
+	});
+
+	define(VM.prototype, {
+		derivedProp: {
+			get: function() {
+				return 'someString';
+			},
+			Type: { foo: 'string' }
+		}
+	});
+
+	assert.equal(finishErrorCheck(), 1);
+
+	message = "can-define: type value for property "+canReflect.getName(VM.prototype)+".derivedProp ignored, as its definition has a zero-argument getter";
+	finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
+
+		assert.equal(actualMessage, message, "Warning is expected message");
+		assert.ok(success);
+	});
+
+	define(VM.prototype, {
+		derivedProp: {
+			get: function() {
+				return 'someString';
+			},
+			type: 'string'
 		}
 	});
 


### PR DESCRIPTION
This PR fixes two issues - It warns when you have `type` or `Type` with a zero argument `getter` and also fixes `Default` to warn even when the the default value is falsey (currently it only warned when `default` had non-falsey values)

closes #465 
closes #466