### PR TITLE
468  remove false warning if only  default type

### DIFF
--- a/can-define.js
+++ b/can-define.js
@@ -233,13 +233,18 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 
 	//!steal-remove-start
 	if(process.env.NODE_ENV !== 'production') {
-		if(definition.get && definition.get.length === 0 && ( "default" in definition || "Default" in definition ) ) {
-				canLogDev.warn("can-define: Default value for property " +
+		if(definition.get && definition.get.length === 0 && !definition.set &&
+			( "default" in definition || "Default" in definition ) ) {
+			var defaultOrDefault = definition.default ? 'default' : 'Default';
+				canLogDev.warn("can-define: " + defaultOrDefault + " value for property " +
 						canReflect.getName(typePrototype)+"."+ prop +
 						" ignored, as its definition has a zero-argument getter");
 		}
 
-		if(definition.get && definition.get.length === 0 && ((definition.type && definition.type !== defaultDefinition.type) || (definition.Type && definition.Type !== defaultDefinition.Type))) {
+		if(definition.get && definition.get.length === 0 && !definition.set &&
+			((definition.type && definition.type !== defaultDefinition.type) ||
+				(definition.Type && definition.Type !== defaultDefinition.Type))
+			) {
 			var warning = definition.type ? 'type' : 'Type';
 			canLogDev.warn("can-define: " + warning + " value for property " +
 					canReflect.getName(typePrototype)+"."+ prop +

--- a/can-define.js
+++ b/can-define.js
@@ -235,18 +235,19 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 	if(process.env.NODE_ENV !== 'production') {
 		var hasZeroArgGetter = definition.get && definition.get.length === 0;
 		var noSetter = !definition.set;
-		var hasEitherDefault = ( "default" in definition || "Default" in definition );
-		var hasEitherType = (definition.type && definition.type !== defaultDefinition.type) || (definition.Type && definition.Type !== defaultDefinition.Type);
+		var defaultInDefinition = ( "default" in definition || "Default" in definition );
+		var typeInDefinition = (definition.type && defaultDefinition && definition.type !== defaultDefinition.type)
+											||	(definition.Type && defaultDefinition && definition.Type !== defaultDefinition.Type);
 
-		if(hasZeroArgGetter && noSetter && hasEitherDefault) {
-			var defaultOrDefault = definition.default ? 'default' : 'Default';
+		if(hasZeroArgGetter && noSetter && defaultInDefinition) {
+			var defaultOrDefault = "default" in definition ? "default" : "Default";
 				canLogDev.warn("can-define: " + defaultOrDefault + " value for property " +
 						canReflect.getName(typePrototype)+"."+ prop +
 						" ignored, as its definition has a zero-argument getter");
 		}
 
-		if(hasZeroArgGetter && noSetter && hasEitherType) {
-			var typeOrType = definition.type ? 'type' : 'Type';
+		if(hasZeroArgGetter && noSetter && typeInDefinition) {
+			var typeOrType = definition.type ? "type" : "Type";
 			canLogDev.warn("can-define: " + typeOrType + " value for property " +
 					canReflect.getName(typePrototype)+"."+ prop +
 					" ignored, as its definition has a zero-argument getter");

--- a/can-define.js
+++ b/can-define.js
@@ -233,20 +233,21 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 
 	//!steal-remove-start
 	if(process.env.NODE_ENV !== 'production') {
-		if(definition.get && definition.get.length === 0 && !definition.set &&
-			( "default" in definition || "Default" in definition ) ) {
+		var hasZeroArgGetter = definition.get && definition.get.length === 0;
+		var noSetter = !definition.set;
+		var hasEitherDefault = ( "default" in definition || "Default" in definition );
+		var hasEitherType = (definition.type && definition.type !== defaultDefinition.type) || (definition.Type && definition.Type !== defaultDefinition.Type);
+
+		if(hasZeroArgGetter && noSetter && hasEitherDefault) {
 			var defaultOrDefault = definition.default ? 'default' : 'Default';
 				canLogDev.warn("can-define: " + defaultOrDefault + " value for property " +
 						canReflect.getName(typePrototype)+"."+ prop +
 						" ignored, as its definition has a zero-argument getter");
 		}
 
-		if(definition.get && definition.get.length === 0 && !definition.set &&
-			((definition.type && definition.type !== defaultDefinition.type) ||
-				(definition.Type && definition.Type !== defaultDefinition.Type))
-			) {
-			var warning = definition.type ? 'type' : 'Type';
-			canLogDev.warn("can-define: " + warning + " value for property " +
+		if(hasZeroArgGetter && noSetter && hasEitherType) {
+			var typeOrType = definition.type ? 'type' : 'Type';
+			canLogDev.warn("can-define: " + typeOrType + " value for property " +
 					canReflect.getName(typePrototype)+"."+ prop +
 					" ignored, as its definition has a zero-argument getter");
 		}

--- a/can-define.js
+++ b/can-define.js
@@ -236,8 +236,8 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 		var hasZeroArgGetter = definition.get && definition.get.length === 0;
 		var noSetter = !definition.set;
 		var defaultInDefinition = ( "default" in definition || "Default" in definition );
-		var typeInDefinition = (definition.type && defaultDefinition && definition.type !== defaultDefinition.type)
-											||	(definition.Type && defaultDefinition && definition.Type !== defaultDefinition.Type);
+		var typeInDefinition = (definition.type && defaultDefinition && definition.type !== defaultDefinition.type) ||
+			(definition.Type && defaultDefinition && definition.Type !== defaultDefinition.Type);
 
 		if(hasZeroArgGetter && noSetter && defaultInDefinition) {
 			var defaultOrDefault = "default" in definition ? "default" : "Default";

--- a/can-define.js
+++ b/can-define.js
@@ -239,7 +239,7 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 						" ignored, as its definition has a zero-argument getter");
 		}
 
-		if(definition.get && definition.get.length === 0 && ( definition.type || definition.Type ) ) {
+		if(definition.get && definition.get.length === 0 && ((definition.type && definition.type !== defaultDefinition.type) || (definition.Type && definition.Type !== defaultDefinition.Type))) {
 			var warning = definition.type ? 'type' : 'Type';
 			canLogDev.warn("can-define: " + warning + " value for property " +
 					canReflect.getName(typePrototype)+"."+ prop +

--- a/test/test-define-only.js
+++ b/test/test-define-only.js
@@ -1493,6 +1493,17 @@ testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored"
 			warning: /default value for property .* ignored/,
 			setProp: false,
 			expectedWarnings: 0
+		},
+		{
+			name: "Default with zero-arg getter, with setter - should not warn",
+			definition: {
+				Default: function () {},
+				get() { return "whatever"; },
+				set (val) { return val; }
+			},
+			warning: /Default value for property .* ignored/,
+			setProp: false,
+			expectedWarnings: 0
 		}
 	];
 
@@ -1502,9 +1513,9 @@ testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored"
 
 		define(VM.prototype, {
 			derivedProp: testCase.definition,
-			// "*": { // emulates can-define/map/map setting default type
-			// 	type: define.types.observable
-			// }
+			"*": { // emulates can-define/map/map setting default type
+				type: define.types.observable
+			}
 		});
 
 		var vm = new VM();

--- a/test/test-define-only.js
+++ b/test/test-define-only.js
@@ -1182,164 +1182,6 @@ QUnit.test('defined properties are configurable', function(assert) {
 	assert.equal(a.val, "bar", "It was redefined");
 });
 
-testHelpers.dev.devOnlyTest("Setting a value with only a get() generates a warning (#202)", function (assert) {
-	assert.expect(7);
-
-	var VM = function() {};
-
-	var message = "can-define: Set value for property "+canReflect.getName(VM.prototype)+".derivedProp ignored, as its definition has a zero-argument getter and no setter";
-	var finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
-
-		assert.equal(actualMessage, message, "Warning is expected message");
-		assert.ok(success);
-	});
-
-
-	define(VM.prototype, {
-		derivedProp: {
-			get: function() {
-				return "Hello World";
-			}
-		}
-	});
-
-	var vm = new VM();
-	vm.on("derivedProp", function() {});
-
-	vm.derivedProp = 'prop is set';
-	assert.equal(vm.derivedProp, "Hello World", "Getter value is preserved");
-
-	VM.shortName = "VM";
-
-	assert.equal(finishErrorCheck(), 1);
-
-	message = "can-define: Set value for property "+canReflect.getName(VM.prototype)+".derivedProp ignored, as its definition has a zero-argument getter and no setter";
-	finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
-		assert.equal(actualMessage, message, "Warning is expected message");
-		assert.ok(success);
-	});
-
-	vm.derivedProp = 'prop is set';
-	assert.equal(finishErrorCheck(), 1);
-});
-
-testHelpers.dev.devOnlyTest("Setter with getter that doesn't take `lastSet` warns (#367)", function (assert) {
-	assert.expect(3);
-
-	var VM = function() {};
-
-	var message = "can-define: Set value for property "+canReflect.getName(VM.prototype)+".derivedProp ignored, as its definition has a zero-argument getter";
-	var finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
-
-		assert.equal(actualMessage, message, "Warning is expected message");
-		assert.ok(success);
-	});
-
-
-	define(VM.prototype, {
-		derivedProp: {
-			set: function(testVar) {
-				return testVar;
-			},
-			get: function() {
-				return "Bitovi Is Awesome";
-			}
-		}
-	});
-
-	assert.equal(finishErrorCheck(), 1);
-
-});
-
-testHelpers.dev.devOnlyTest("Getter with Type or type that doesn't take `lastSet` should warn (#465)", function (assert) {
-	assert.expect(6);
-
-	var VM = function() {};
-
-	var message = "can-define: Type value for property "+canReflect.getName(VM.prototype)+".derivedProp ignored, as its definition has a zero-argument getter";
-	var finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
-
-		assert.equal(actualMessage, message, "Warning is expected message");
-		assert.ok(success);
-	});
-
-	define(VM.prototype, {
-		derivedProp: {
-			get: function() {
-				return 'someString';
-			},
-			Type: { foo: 'string' }
-		}
-	});
-
-	assert.equal(finishErrorCheck(), 1);
-
-	message = "can-define: type value for property "+canReflect.getName(VM.prototype)+".derivedProp ignored, as its definition has a zero-argument getter";
-	finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
-
-		assert.equal(actualMessage, message, "Warning is expected message");
-		assert.ok(success);
-	});
-
-	define(VM.prototype, {
-		derivedProp: {
-			get: function() {
-				return 'someString';
-			},
-			type: 'string'
-		}
-	});
-
-	assert.equal(finishErrorCheck(), 1);
-
-});
-
-testHelpers.dev.devOnlyTest("Default with getter that doesn't take `lastSet` warns (#367)", function (assert) {
-	assert.expect(6);
-
-	var VM = function() {};
-
-	var message = "can-define: Default value for property "+canReflect.getName(VM.prototype)+".derivedProp ignored, as its definition has a zero-argument getter";
-
-	var finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
-
-		assert.equal(actualMessage, message, "Warning is expected message");
-		assert.ok(success);
-	});
-
-
-	define(VM.prototype, {
-		derivedProp: {
-			default: 'Amechi Egbe',
-			get: function() {
-				return "I Love Software";
-			}
-		}
-	});
-
-	assert.equal(finishErrorCheck(), 1, 'There was 1 warning');
-
-	message = "can-define: Default value for property "+canReflect.getName(VM.prototype)+".derivedProp ignored, as its definition has a zero-argument getter";
-	finishErrorCheck = testHelpers.dev.willWarn(message, function(actualMessage, success) {
-
-		assert.equal(actualMessage, message, "Warning is expected message");
-		assert.ok(success);
-	});
-
-
-	define(VM.prototype, {
-		derivedProp: {
-			default: '',
-			get: function() {
-				return "I Love Software";
-			}
-		}
-	});
-
-	assert.equal(finishErrorCheck(), 1, 'There was 1 warning');
-
-});
-
 testHelpers.dev.devOnlyTest("warn on using a Constructor for small-t type definitions", function (assert) {
 	assert.expect(1);
 
@@ -1559,27 +1401,122 @@ testHelpers.dev.devOnlyTest("warning when setting during a get (setter)", functi
 	teardownWarn();
 });
 
-testHelpers.dev.devOnlyTest("Getter that doesn't take `lastSet` without explicit Type or type should NOT warn (#468)", function (assert) {
-	assert.expect(1);
-
-	var VM = function() {};
-
-	var message = "can-define: type value for property "+canReflect.getName(VM.prototype)+".derivedProp ignored, as its definition has a zero-argument getter";
-	var finishErrorCheck = testHelpers.dev.willWarn(message);
-
-	define(VM.prototype, {
-		derivedProp: {
-			get: function() {
-				return 'someString';
-			}
+testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored", function(assert) {
+	var testCases = [
+		{
+			name: "zero-arg getter, no setter when property is set",
+			definition: {
+				get() { return "whatever"; }
+			},
+			warning: /Set value for property .* ignored/,
+			setProp: true,
+			expectedWarnings: 1
 		},
-		"*": { // emulates can-define/map/map setting default type
-			type: define.types.observable
+		{
+			name: "type with zero-arg getter, no setter",
+			definition: {
+				type: String,
+				get() { return "whatever"; }
+			},
+			warning: /type value for property .* ignored/,
+			setProp: false,
+			expectedWarnings: 1
+		},
+		{
+			name: "Type with zero-arg getter, no setter",
+			definition: {
+				Type: {},
+				get() { return "whatever"; }
+			},
+			warning: /Type value for property .* ignored/,
+			setProp: false,
+			expectedWarnings: 1
+		},
+		{
+			name: "only default type with zero-arg getter, no setter - should not warn",
+			definition: {
+				get() { return "whatever"; }
+			},
+			warning: /type value for property .* ignored/,
+			setProp: false,
+			expectedWarnings: 0
+		},
+		{
+			name: "type with zero-arg getter, with setter - should not warn",
+			definition: {
+				type: String,
+				get() { return "whatever"; },
+				set (val) { return val; }
+			},
+			warning: /type value for property .* ignored/,
+			setProp: false,
+			expectedWarnings: 0
+		},
+		{
+			name: "Type with zero-arg getter, with setter - should not warn",
+			definition: {
+				Type: {},
+				get() { return "whatever"; },
+				set (val) { return val; }
+			},
+			warning: /Type value for property .* ignored/,
+			setProp: false,
+			expectedWarnings: 0
+		},
+		{
+			name: "default with zero-arg getter, no setter",
+			definition: {
+				default: "some thing",
+				get() { return "whatever"; }
+			},
+			warning: /default value for property .* ignored/,
+			setProp: false,
+			expectedWarnings: 1
+		},
+		{
+			name: "Default with zero-arg getter, no setter",
+			definition: {
+				Default: function () {},
+				get() { return "whatever"; }
+			},
+			warning: /Default value for property .* ignored/,
+			setProp: false,
+			expectedWarnings: 1
+		},
+		{
+			name: "default with zero-arg getter, with setter - should not warn",
+			definition: {
+				default: "some thing",
+				get() { return "whatever"; },
+				set (val) { return val; }
+			},
+			warning: /default value for property .* ignored/,
+			setProp: false,
+			expectedWarnings: 0
 		}
+	];
+
+	testCases.forEach((testCase) => {
+		var VM = function() {};
+		var warnCount = testHelpers.dev.willWarn(testCase.warning);
+
+		define(VM.prototype, {
+			derivedProp: testCase.definition,
+			// "*": { // emulates can-define/map/map setting default type
+			// 	type: define.types.observable
+			// }
+		});
+
+		var vm = new VM();
+
+		// read prop for 'lazy' setup
+		canReflect.onKeyValue(vm, 'derivedProp', function() {});
+
+		if (testCase.setProp) {
+			vm.derivedProp = "smashed it!";
+		}
+
+
+		assert.equal(warnCount(), testCase.expectedWarnings, `got correct number of warnings for "${testCase.name}"`);
 	});
-
-	var vm = new VM();
-	canReflect.onKeyValue(vm, 'derivedProp', function() {});
-
-	assert.equal(finishErrorCheck(), 0);
 });

--- a/test/test-define-only.js
+++ b/test/test-define-only.js
@@ -1406,7 +1406,7 @@ testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored"
 		{
 			name: "zero-arg getter, no setter when property is set",
 			definition: {
-				get() { return "whatever"; }
+				get: function() { return "whatever"; }
 			},
 			warning: /Set value for property .* ignored/,
 			setProp: true,
@@ -1416,7 +1416,7 @@ testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored"
 			name: "type with zero-arg getter, no setter",
 			definition: {
 				type: String,
-				get() { return "whatever"; }
+				get: function() { return "whatever"; }
 			},
 			warning: /type value for property .* ignored/,
 			setProp: false,
@@ -1426,7 +1426,7 @@ testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored"
 			name: "Type with zero-arg getter, no setter",
 			definition: {
 				Type: {},
-				get() { return "whatever"; }
+				get: function() { return "whatever"; }
 			},
 			warning: /Type value for property .* ignored/,
 			setProp: false,
@@ -1435,7 +1435,7 @@ testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored"
 		{
 			name: "only default type with zero-arg getter, no setter - should not warn",
 			definition: {
-				get() { return "whatever"; }
+				get: function() { return "whatever"; }
 			},
 			warning: /type value for property .* ignored/,
 			setProp: false,
@@ -1445,8 +1445,8 @@ testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored"
 			name: "type with zero-arg getter, with setter - should not warn",
 			definition: {
 				type: String,
-				get() { return "whatever"; },
-				set (val) { return val; }
+				get: function() { return "whatever"; },
+				set: function (val) { return val; }
 			},
 			warning: /type value for property .* ignored/,
 			setProp: false,
@@ -1456,8 +1456,8 @@ testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored"
 			name: "Type with zero-arg getter, with setter - should not warn",
 			definition: {
 				Type: {},
-				get() { return "whatever"; },
-				set (val) { return val; }
+				get: function() { return "whatever"; },
+				set: function (val) { return val; }
 			},
 			warning: /Type value for property .* ignored/,
 			setProp: false,
@@ -1467,7 +1467,7 @@ testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored"
 			name: "default with zero-arg getter, no setter",
 			definition: {
 				default: "some thing",
-				get() { return "whatever"; }
+				get: function() { return "whatever"; }
 			},
 			warning: /default value for property .* ignored/,
 			setProp: false,
@@ -1477,7 +1477,7 @@ testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored"
 			name: "Default with zero-arg getter, no setter",
 			definition: {
 				Default: function () {},
-				get() { return "whatever"; }
+				get: function() { return "whatever"; }
 			},
 			warning: /Default value for property .* ignored/,
 			setProp: false,
@@ -1487,8 +1487,8 @@ testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored"
 			name: "default with zero-arg getter, with setter - should not warn",
 			definition: {
 				default: "some thing",
-				get() { return "whatever"; },
-				set (val) { return val; }
+				get: function() { return "whatever"; },
+				set: function (val) { return val; }
 			},
 			warning: /default value for property .* ignored/,
 			setProp: false,
@@ -1498,8 +1498,8 @@ testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored"
 			name: "Default with zero-arg getter, with setter - should not warn",
 			definition: {
 				Default: function () {},
-				get() { return "whatever"; },
-				set (val) { return val; }
+				get: function() { return "whatever"; },
+				set: function (val) { return val; }
 			},
 			warning: /Default value for property .* ignored/,
 			setProp: false,
@@ -1507,7 +1507,7 @@ testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored"
 		}
 	];
 
-	testCases.forEach((testCase) => {
+	testCases.forEach(function(testCase) {
 		var VM = function() {};
 		var warnCount = testHelpers.dev.willWarn(testCase.warning);
 
@@ -1528,6 +1528,6 @@ testHelpers.dev.devOnlyTest("warnings are given when type or default is ignored"
 		}
 
 
-		assert.equal(warnCount(), testCase.expectedWarnings, `got correct number of warnings for "${testCase.name}"`);
+		assert.equal(warnCount(), testCase.expectedWarnings, "got correct number of warnings for " + testCase.name);
 	});
 });

--- a/test/test-define-only.js
+++ b/test/test-define-only.js
@@ -1558,3 +1558,28 @@ testHelpers.dev.devOnlyTest("warning when setting during a get (setter)", functi
 	inst.prop2 = "quux";
 	teardownWarn();
 });
+
+testHelpers.dev.devOnlyTest("Getter that doesn't take `lastSet` without explicit Type or type should NOT warn (#468)", function (assert) {
+	assert.expect(1);
+
+	var VM = function() {};
+
+	var message = "can-define: type value for property "+canReflect.getName(VM.prototype)+".derivedProp ignored, as its definition has a zero-argument getter";
+	var finishErrorCheck = testHelpers.dev.willWarn(message);
+
+	define(VM.prototype, {
+		derivedProp: {
+			get: function() {
+				return 'someString';
+			}
+		},
+		"*": { // emulates can-define/map/map setting default type
+			type: define.types.observable
+		}
+	});
+
+	var vm = new VM();
+	canReflect.onKeyValue(vm, 'derivedProp', function() {});
+
+	assert.equal(finishErrorCheck(), 0);
+});


### PR DESCRIPTION
This removes a 'false positive' warning for `type` being ignored with a zero-arg getter.  It now allows the default `type` set by `can-define/map/map` to exist with a zero-arg getter, and not warn. 

Closes #468 