### PR TITLE
change can-core to can-legacy for docs

### DIFF
--- a/docs/define.md
+++ b/docs/define.md
@@ -1,6 +1,6 @@
 @module {function} can-define
 @parent can-observables
-@collection can-core
+@collection can-legacy
 @description Defines observable properties and their behavior on a prototype object. This
 function is not commonly used directly. [can-define/map/map]
 and [can-define/list/list] are more commonly used. Types and

--- a/list/docs/define-list.md
+++ b/list/docs/define-list.md
@@ -1,6 +1,6 @@
 @module {function} can-define/list/list
 @parent can-observables
-@collection can-core
+@collection can-legacy
 @group can-define/list/list.prototype prototype
 @group can-define/list/list/events events
 @alias can.DefineList

--- a/map/docs/define-map.md
+++ b/map/docs/define-map.md
@@ -1,6 +1,6 @@
 @module {function} can-define/map/map
 @parent can-observables
-@collection can-core
+@collection can-legacy
 @group can-define/map/map.prototype prototype
 @group can-define/map/map.static static
 @group can-define/map/map/events events


### PR DESCRIPTION
Moving `can-define` from `can-core` into `can-legacy` for documentation.

Related to https://github.com/canjs/canjs/issues/5170