### PR TITLE
Fix DefineMap/DefineList failing isObservableLike on IE11 (Win 8.1)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -51,5 +51,6 @@
 	"browser": true,
 	"phantom": true,
 	"rhino": true,
-	"node": true
+	"node": true,
+	"esversion": 6
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: node_js
 node_js: node
 addons:
-  firefox: '51.0'
-dist: xenial
+  firefox: latest
+dist: focal
 services:
   - xvfb

--- a/list/list.js
+++ b/list/list.js
@@ -342,9 +342,12 @@ for(var prop in define.eventsProto) {
 	});
 }
 
-var eventsProtoSymbols = ("getOwnPropertySymbols" in Object) ?
-  Object.getOwnPropertySymbols(define.eventsProto) :
-  [canSymbol.for("can.onKeyValue"), canSymbol.for("can.offKeyValue")];
+var eventsProtoSymbols = (
+	"getOwnPropertySymbols" in Object &&
+	typeof canSymbol("symbol") === "symbol"
+) ?
+	Object.getOwnPropertySymbols(define.eventsProto) :
+	[canSymbol.for("can.onKeyValue"), canSymbol.for("can.offKeyValue")];
 
 eventsProtoSymbols.forEach(function(sym) {
   Object.defineProperty(DefineList.prototype, sym, {

--- a/map/map.js
+++ b/map/map.js
@@ -294,17 +294,20 @@ function getSymbolsForIE(obj){
 	});
 }
 // Copy symbols over, but they aren't supported in IE
-var eventsProtoSymbols = ("getOwnPropertySymbols" in Object) ?
-  Object.getOwnPropertySymbols(define.eventsProto) :
-  getSymbolsForIE(define.eventsProto);
+var eventsProtoSymbols = (
+	"getOwnPropertySymbols" in Object &&
+	typeof canSymbol("symbol") === "symbol"
+) ?
+	Object.getOwnPropertySymbols(define.eventsProto) :
+	getSymbolsForIE(define.eventsProto);
 
 eventsProtoSymbols.forEach(function(sym) {
-  Object.defineProperty(DefineMap.prototype, sym, {
-  	configurable: true,
-    enumerable:false,
-    value: define.eventsProto[sym],
-    writable: true
-  });
+	Object.defineProperty(DefineMap.prototype, sym, {
+		configurable: true,
+		enumerable:false,
+		value: define.eventsProto[sym],
+		writable: true
+	});
 });
 
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "can-reflect-tests": "^1.0.0",
     "can-test-helpers": "^1.1.4",
     "detect-cyclic-packages": "^1.1.0",
-    "jshint": "^2.9.1",
+    "jshint": "^2.13.6",
     "serve": "^11.0.0",
     "steal": "^2.0.0",
     "steal-qunit": "^2.0.0",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
